### PR TITLE
Item detail heroes with material selectors, paginated tables

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,15 +1,34 @@
 import { useState } from "react"
+import { Link } from "@tanstack/react-router"
 import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
   type ColumnDef,
+  type Row,
   type SortingState,
 } from "@tanstack/react-table"
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react"
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronsLeft,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsRight,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   Table,
   TableBody,
@@ -24,6 +43,8 @@ interface DataTableProps<T> {
   columns: ColumnDef<T>[]
   searchPlaceholder?: string
   isLoading?: boolean
+  getRowLink?: (row: Row<T>) => { to: string; params: Record<string, string> }
+  pageSize?: number
 }
 
 export function DataTable<T>({
@@ -31,6 +52,8 @@ export function DataTable<T>({
   columns,
   searchPlaceholder = "Search...",
   isLoading,
+  getRowLink,
+  pageSize = 10,
 }: DataTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState("")
@@ -44,18 +67,27 @@ export function DataTable<T>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize } },
   })
+
+  const filtered = table.getFilteredRowModel().rows.length
+  const page = table.getState().pagination.pageIndex
+  const totalPages = table.getPageCount()
 
   return (
     <div className="space-y-4">
       <Input
         placeholder={searchPlaceholder}
         value={globalFilter}
-        onChange={(e) => setGlobalFilter(e.target.value)}
+        onChange={(e) => {
+          setGlobalFilter(e.target.value)
+          table.setPageIndex(0)
+        }}
         className="max-w-sm"
       />
-      <div className="max-h-[70vh] overflow-auto overscroll-contain rounded-md border">
-        <Table>
+      <div className="overflow-x-auto rounded-md border">
+        <Table className="table-fixed">
           <TableHeader>
             {table.getHeaderGroups().map((hg) => (
               <TableRow key={hg.id}>
@@ -103,25 +135,121 @@ export function DataTable<T>({
                 </TableCell>
               </TableRow>
             ) : (
-              table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
+              table.getRowModel().rows.map((row) => {
+                const link = getRowLink?.(row)
+
+                if (link) {
+                  return (
+                    <TableRow
+                      key={row.id}
+                      className="hover:bg-muted/50 cursor-pointer"
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id} className="p-0">
+                          <Link
+                            to={link.to}
+                            params={link.params}
+                            className="block px-4 py-2"
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </Link>
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  )
+                }
+
+                return (
+                  <TableRow key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                )
+              })
             )}
           </TableBody>
         </Table>
       </div>
-      <p className="text-muted-foreground text-xs">
-        {table.getFilteredRowModel().rows.length} items
-      </p>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <p className="text-muted-foreground text-xs">
+            {filtered} item{filtered !== 1 && "s"}
+          </p>
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground text-xs">Rows</span>
+            <Select
+              value={String(table.getState().pagination.pageSize)}
+              onValueChange={(v) => {
+                table.setPageSize(Number(v))
+                table.setPageIndex(0)
+              }}
+            >
+              <SelectTrigger className="h-7 w-20 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[10, 25, 50, 100].map((size) => (
+                  <SelectItem key={size} value={String(size)}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        {totalPages > 1 && (
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.setPageIndex(0)}
+              disabled={!table.getCanPreviousPage()}
+              className="h-7 w-7 p-0"
+            >
+              <ChevronsLeft className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+              className="h-7 w-7 p-0"
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <span className="text-muted-foreground px-2 text-xs">
+              {page + 1} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+              className="h-7 w-7 p-0"
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.setPageIndex(totalPages - 1)}
+              disabled={!table.getCanNextPage()}
+              className="h-7 w-7 p-0"
+            >
+              <ChevronsRight className="size-4" />
+            </Button>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/pages/armor/armor-page.tsx
+++ b/src/pages/armor/armor-page.tsx
@@ -46,20 +46,16 @@ export function ArmorPage() {
   )
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <div>
-        <h1 className="text-3xl tracking-wide sm:text-4xl">Armor</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          All {data.length} armor pieces in Vagrant Story
-        </p>
-      </div>
-      <DataTable
-        data={enriched}
-        columns={columns}
-        searchPlaceholder="Search armor..."
-        isLoading={isLoading}
-      />
-    </div>
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search armor..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/armor/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
   )
 }
 

--- a/src/pages/consumables/consumables-page.tsx
+++ b/src/pages/consumables/consumables-page.tsx
@@ -71,19 +71,15 @@ export function ConsumablesPage() {
   )
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <div>
-        <h1 className="text-3xl tracking-wide sm:text-4xl">Consumables</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          Items that can be used from inventory during gameplay
-        </p>
-      </div>
-      <DataTable
-        data={enriched}
-        columns={columns}
-        searchPlaceholder="Search consumables..."
-        isLoading={isLoading}
-      />
-    </div>
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search consumables..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/consumables/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
   )
 }

--- a/src/pages/gems/gems-page.tsx
+++ b/src/pages/gems/gems-page.tsx
@@ -31,19 +31,15 @@ export function GemsPage() {
   )
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <div>
-        <h1 className="text-3xl tracking-wide sm:text-4xl">Gems</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          Gems can be attached to equipment with gem slots
-        </p>
-      </div>
-      <DataTable
-        data={enriched}
-        columns={columns}
-        searchPlaceholder="Search gems..."
-        isLoading={isLoading}
-      />
-    </div>
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search gems..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/gems/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
   )
 }

--- a/src/pages/grips/grips-page.tsx
+++ b/src/pages/grips/grips-page.tsx
@@ -61,20 +61,16 @@ export function GripsPage() {
   )
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <div>
-        <h1 className="text-3xl tracking-wide sm:text-4xl">Grips</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          Grips modify weapon stats and can be swapped between weapons
-        </p>
-      </div>
-      <DataTable
-        data={enriched}
-        columns={columns}
-        searchPlaceholder="Search grips..."
-        isLoading={isLoading}
-      />
-    </div>
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search grips..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/grips/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
   )
 }
 

--- a/src/pages/weapons/weapons-page.tsx
+++ b/src/pages/weapons/weapons-page.tsx
@@ -49,20 +49,16 @@ export function WeaponsPage() {
   )
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <div>
-        <h1 className="text-3xl tracking-wide sm:text-4xl">Weapons</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          All {data.length} blades in Vagrant Story
-        </p>
-      </div>
-      <DataTable
-        data={enriched}
-        columns={columns}
-        searchPlaceholder="Search weapons..."
-        isLoading={isLoading}
-      />
-    </div>
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search weapons..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/weapons/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
   )
 }
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,7 +9,6 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as WeaponsRouteImport } from './routes/weapons'
 import { Route as MaterialsRouteImport } from './routes/materials'
 import { Route as MaterialGridRouteImport } from './routes/material-grid'
 import { Route as GripsRouteImport } from './routes/grips'
@@ -17,14 +16,12 @@ import { Route as GemsRouteImport } from './routes/gems'
 import { Route as ConsumablesRouteImport } from './routes/consumables'
 import { Route as ArmorRouteImport } from './routes/armor'
 import { Route as SplatRouteImport } from './routes/$'
+import { Route as WeaponsRouteRouteImport } from './routes/weapons/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as WeaponsIndexRouteImport } from './routes/weapons/index'
 import { Route as CraftingIndexRouteImport } from './routes/crafting/index'
+import { Route as WeaponsIdRouteImport } from './routes/weapons/$id'
 
-const WeaponsRoute = WeaponsRouteImport.update({
-  id: '/weapons',
-  path: '/weapons',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const MaterialsRoute = MaterialsRouteImport.update({
   id: '/materials',
   path: '/materials',
@@ -60,19 +57,35 @@ const SplatRoute = SplatRouteImport.update({
   path: '/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const WeaponsRouteRoute = WeaponsRouteRouteImport.update({
+  id: '/weapons',
+  path: '/weapons',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const WeaponsIndexRoute = WeaponsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => WeaponsRouteRoute,
 } as any)
 const CraftingIndexRoute = CraftingIndexRouteImport.update({
   id: '/crafting/',
   path: '/crafting/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const WeaponsIdRoute = WeaponsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => WeaponsRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/weapons': typeof WeaponsRouteRouteWithChildren
   '/$': typeof SplatRoute
   '/armor': typeof ArmorRoute
   '/consumables': typeof ConsumablesRoute
@@ -80,8 +93,9 @@ export interface FileRoutesByFullPath {
   '/grips': typeof GripsRoute
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
-  '/weapons': typeof WeaponsRoute
+  '/weapons/$id': typeof WeaponsIdRoute
   '/crafting/': typeof CraftingIndexRoute
+  '/weapons/': typeof WeaponsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -92,12 +106,14 @@ export interface FileRoutesByTo {
   '/grips': typeof GripsRoute
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
-  '/weapons': typeof WeaponsRoute
+  '/weapons/$id': typeof WeaponsIdRoute
   '/crafting': typeof CraftingIndexRoute
+  '/weapons': typeof WeaponsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/weapons': typeof WeaponsRouteRouteWithChildren
   '/$': typeof SplatRoute
   '/armor': typeof ArmorRoute
   '/consumables': typeof ConsumablesRoute
@@ -105,13 +121,15 @@ export interface FileRoutesById {
   '/grips': typeof GripsRoute
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
-  '/weapons': typeof WeaponsRoute
+  '/weapons/$id': typeof WeaponsIdRoute
   '/crafting/': typeof CraftingIndexRoute
+  '/weapons/': typeof WeaponsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/weapons'
     | '/$'
     | '/armor'
     | '/consumables'
@@ -119,8 +137,9 @@ export interface FileRouteTypes {
     | '/grips'
     | '/material-grid'
     | '/materials'
-    | '/weapons'
+    | '/weapons/$id'
     | '/crafting/'
+    | '/weapons/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -131,11 +150,13 @@ export interface FileRouteTypes {
     | '/grips'
     | '/material-grid'
     | '/materials'
-    | '/weapons'
+    | '/weapons/$id'
     | '/crafting'
+    | '/weapons'
   id:
     | '__root__'
     | '/'
+    | '/weapons'
     | '/$'
     | '/armor'
     | '/consumables'
@@ -143,12 +164,14 @@ export interface FileRouteTypes {
     | '/grips'
     | '/material-grid'
     | '/materials'
-    | '/weapons'
+    | '/weapons/$id'
     | '/crafting/'
+    | '/weapons/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  WeaponsRouteRoute: typeof WeaponsRouteRouteWithChildren
   SplatRoute: typeof SplatRoute
   ArmorRoute: typeof ArmorRoute
   ConsumablesRoute: typeof ConsumablesRoute
@@ -156,19 +179,11 @@ export interface RootRouteChildren {
   GripsRoute: typeof GripsRoute
   MaterialGridRoute: typeof MaterialGridRoute
   MaterialsRoute: typeof MaterialsRoute
-  WeaponsRoute: typeof WeaponsRoute
   CraftingIndexRoute: typeof CraftingIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/weapons': {
-      id: '/weapons'
-      path: '/weapons'
-      fullPath: '/weapons'
-      preLoaderRoute: typeof WeaponsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/materials': {
       id: '/materials'
       path: '/materials'
@@ -218,12 +233,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/weapons': {
+      id: '/weapons'
+      path: '/weapons'
+      fullPath: '/weapons'
+      preLoaderRoute: typeof WeaponsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/weapons/': {
+      id: '/weapons/'
+      path: '/'
+      fullPath: '/weapons/'
+      preLoaderRoute: typeof WeaponsIndexRouteImport
+      parentRoute: typeof WeaponsRouteRoute
     }
     '/crafting/': {
       id: '/crafting/'
@@ -232,11 +261,33 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CraftingIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/weapons/$id': {
+      id: '/weapons/$id'
+      path: '/$id'
+      fullPath: '/weapons/$id'
+      preLoaderRoute: typeof WeaponsIdRouteImport
+      parentRoute: typeof WeaponsRouteRoute
+    }
   }
 }
 
+interface WeaponsRouteRouteChildren {
+  WeaponsIdRoute: typeof WeaponsIdRoute
+  WeaponsIndexRoute: typeof WeaponsIndexRoute
+}
+
+const WeaponsRouteRouteChildren: WeaponsRouteRouteChildren = {
+  WeaponsIdRoute: WeaponsIdRoute,
+  WeaponsIndexRoute: WeaponsIndexRoute,
+}
+
+const WeaponsRouteRouteWithChildren = WeaponsRouteRoute._addFileChildren(
+  WeaponsRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  WeaponsRouteRoute: WeaponsRouteRouteWithChildren,
   SplatRoute: SplatRoute,
   ArmorRoute: ArmorRoute,
   ConsumablesRoute: ConsumablesRoute,
@@ -244,7 +295,6 @@ const rootRouteChildren: RootRouteChildren = {
   GripsRoute: GripsRoute,
   MaterialGridRoute: MaterialGridRoute,
   MaterialsRoute: MaterialsRoute,
-  WeaponsRoute: WeaponsRoute,
   CraftingIndexRoute: CraftingIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,16 +11,24 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as MaterialsRouteImport } from './routes/materials'
 import { Route as MaterialGridRouteImport } from './routes/material-grid'
-import { Route as GripsRouteImport } from './routes/grips'
-import { Route as GemsRouteImport } from './routes/gems'
-import { Route as ConsumablesRouteImport } from './routes/consumables'
-import { Route as ArmorRouteImport } from './routes/armor'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as WeaponsRouteRouteImport } from './routes/weapons/route'
+import { Route as GripsRouteRouteImport } from './routes/grips/route'
+import { Route as GemsRouteRouteImport } from './routes/gems/route'
+import { Route as ConsumablesRouteRouteImport } from './routes/consumables/route'
+import { Route as ArmorRouteRouteImport } from './routes/armor/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WeaponsIndexRouteImport } from './routes/weapons/index'
+import { Route as GripsIndexRouteImport } from './routes/grips/index'
+import { Route as GemsIndexRouteImport } from './routes/gems/index'
 import { Route as CraftingIndexRouteImport } from './routes/crafting/index'
+import { Route as ConsumablesIndexRouteImport } from './routes/consumables/index'
+import { Route as ArmorIndexRouteImport } from './routes/armor/index'
 import { Route as WeaponsIdRouteImport } from './routes/weapons/$id'
+import { Route as GripsIdRouteImport } from './routes/grips/$id'
+import { Route as GemsIdRouteImport } from './routes/gems/$id'
+import { Route as ConsumablesIdRouteImport } from './routes/consumables/$id'
+import { Route as ArmorIdRouteImport } from './routes/armor/$id'
 
 const MaterialsRoute = MaterialsRouteImport.update({
   id: '/materials',
@@ -30,26 +38,6 @@ const MaterialsRoute = MaterialsRouteImport.update({
 const MaterialGridRoute = MaterialGridRouteImport.update({
   id: '/material-grid',
   path: '/material-grid',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const GripsRoute = GripsRouteImport.update({
-  id: '/grips',
-  path: '/grips',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const GemsRoute = GemsRouteImport.update({
-  id: '/gems',
-  path: '/gems',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ConsumablesRoute = ConsumablesRouteImport.update({
-  id: '/consumables',
-  path: '/consumables',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ArmorRoute = ArmorRouteImport.update({
-  id: '/armor',
-  path: '/armor',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SplatRoute = SplatRouteImport.update({
@@ -62,6 +50,26 @@ const WeaponsRouteRoute = WeaponsRouteRouteImport.update({
   path: '/weapons',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GripsRouteRoute = GripsRouteRouteImport.update({
+  id: '/grips',
+  path: '/grips',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GemsRouteRoute = GemsRouteRouteImport.update({
+  id: '/gems',
+  path: '/gems',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConsumablesRouteRoute = ConsumablesRouteRouteImport.update({
+  id: '/consumables',
+  path: '/consumables',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ArmorRouteRoute = ArmorRouteRouteImport.update({
+  id: '/armor',
+  path: '/armor',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -72,111 +80,191 @@ const WeaponsIndexRoute = WeaponsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => WeaponsRouteRoute,
 } as any)
+const GripsIndexRoute = GripsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => GripsRouteRoute,
+} as any)
+const GemsIndexRoute = GemsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => GemsRouteRoute,
+} as any)
 const CraftingIndexRoute = CraftingIndexRouteImport.update({
   id: '/crafting/',
   path: '/crafting/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ConsumablesIndexRoute = ConsumablesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ConsumablesRouteRoute,
+} as any)
+const ArmorIndexRoute = ArmorIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ArmorRouteRoute,
 } as any)
 const WeaponsIdRoute = WeaponsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => WeaponsRouteRoute,
 } as any)
+const GripsIdRoute = GripsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => GripsRouteRoute,
+} as any)
+const GemsIdRoute = GemsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => GemsRouteRoute,
+} as any)
+const ConsumablesIdRoute = ConsumablesIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ConsumablesRouteRoute,
+} as any)
+const ArmorIdRoute = ArmorIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ArmorRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/armor': typeof ArmorRouteRouteWithChildren
+  '/consumables': typeof ConsumablesRouteRouteWithChildren
+  '/gems': typeof GemsRouteRouteWithChildren
+  '/grips': typeof GripsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
   '/$': typeof SplatRoute
-  '/armor': typeof ArmorRoute
-  '/consumables': typeof ConsumablesRoute
-  '/gems': typeof GemsRoute
-  '/grips': typeof GripsRoute
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
+  '/armor/$id': typeof ArmorIdRoute
+  '/consumables/$id': typeof ConsumablesIdRoute
+  '/gems/$id': typeof GemsIdRoute
+  '/grips/$id': typeof GripsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
+  '/armor/': typeof ArmorIndexRoute
+  '/consumables/': typeof ConsumablesIndexRoute
   '/crafting/': typeof CraftingIndexRoute
+  '/gems/': typeof GemsIndexRoute
+  '/grips/': typeof GripsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
-  '/armor': typeof ArmorRoute
-  '/consumables': typeof ConsumablesRoute
-  '/gems': typeof GemsRoute
-  '/grips': typeof GripsRoute
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
+  '/armor/$id': typeof ArmorIdRoute
+  '/consumables/$id': typeof ConsumablesIdRoute
+  '/gems/$id': typeof GemsIdRoute
+  '/grips/$id': typeof GripsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
+  '/armor': typeof ArmorIndexRoute
+  '/consumables': typeof ConsumablesIndexRoute
   '/crafting': typeof CraftingIndexRoute
+  '/gems': typeof GemsIndexRoute
+  '/grips': typeof GripsIndexRoute
   '/weapons': typeof WeaponsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/armor': typeof ArmorRouteRouteWithChildren
+  '/consumables': typeof ConsumablesRouteRouteWithChildren
+  '/gems': typeof GemsRouteRouteWithChildren
+  '/grips': typeof GripsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
   '/$': typeof SplatRoute
-  '/armor': typeof ArmorRoute
-  '/consumables': typeof ConsumablesRoute
-  '/gems': typeof GemsRoute
-  '/grips': typeof GripsRoute
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
+  '/armor/$id': typeof ArmorIdRoute
+  '/consumables/$id': typeof ConsumablesIdRoute
+  '/gems/$id': typeof GemsIdRoute
+  '/grips/$id': typeof GripsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
+  '/armor/': typeof ArmorIndexRoute
+  '/consumables/': typeof ConsumablesIndexRoute
   '/crafting/': typeof CraftingIndexRoute
+  '/gems/': typeof GemsIndexRoute
+  '/grips/': typeof GripsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/weapons'
-    | '/$'
     | '/armor'
     | '/consumables'
     | '/gems'
     | '/grips'
+    | '/weapons'
+    | '/$'
     | '/material-grid'
     | '/materials'
+    | '/armor/$id'
+    | '/consumables/$id'
+    | '/gems/$id'
+    | '/grips/$id'
     | '/weapons/$id'
+    | '/armor/'
+    | '/consumables/'
     | '/crafting/'
+    | '/gems/'
+    | '/grips/'
     | '/weapons/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/$'
-    | '/armor'
-    | '/consumables'
-    | '/gems'
-    | '/grips'
     | '/material-grid'
     | '/materials'
+    | '/armor/$id'
+    | '/consumables/$id'
+    | '/gems/$id'
+    | '/grips/$id'
     | '/weapons/$id'
+    | '/armor'
+    | '/consumables'
     | '/crafting'
+    | '/gems'
+    | '/grips'
     | '/weapons'
   id:
     | '__root__'
     | '/'
-    | '/weapons'
-    | '/$'
     | '/armor'
     | '/consumables'
     | '/gems'
     | '/grips'
+    | '/weapons'
+    | '/$'
     | '/material-grid'
     | '/materials'
+    | '/armor/$id'
+    | '/consumables/$id'
+    | '/gems/$id'
+    | '/grips/$id'
     | '/weapons/$id'
+    | '/armor/'
+    | '/consumables/'
     | '/crafting/'
+    | '/gems/'
+    | '/grips/'
     | '/weapons/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ArmorRouteRoute: typeof ArmorRouteRouteWithChildren
+  ConsumablesRouteRoute: typeof ConsumablesRouteRouteWithChildren
+  GemsRouteRoute: typeof GemsRouteRouteWithChildren
+  GripsRouteRoute: typeof GripsRouteRouteWithChildren
   WeaponsRouteRoute: typeof WeaponsRouteRouteWithChildren
   SplatRoute: typeof SplatRoute
-  ArmorRoute: typeof ArmorRoute
-  ConsumablesRoute: typeof ConsumablesRoute
-  GemsRoute: typeof GemsRoute
-  GripsRoute: typeof GripsRoute
   MaterialGridRoute: typeof MaterialGridRoute
   MaterialsRoute: typeof MaterialsRoute
   CraftingIndexRoute: typeof CraftingIndexRoute
@@ -198,34 +286,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MaterialGridRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/grips': {
-      id: '/grips'
-      path: '/grips'
-      fullPath: '/grips'
-      preLoaderRoute: typeof GripsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/gems': {
-      id: '/gems'
-      path: '/gems'
-      fullPath: '/gems'
-      preLoaderRoute: typeof GemsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/consumables': {
-      id: '/consumables'
-      path: '/consumables'
-      fullPath: '/consumables'
-      preLoaderRoute: typeof ConsumablesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/armor': {
-      id: '/armor'
-      path: '/armor'
-      fullPath: '/armor'
-      preLoaderRoute: typeof ArmorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/$': {
       id: '/$'
       path: '/$'
@@ -238,6 +298,34 @@ declare module '@tanstack/react-router' {
       path: '/weapons'
       fullPath: '/weapons'
       preLoaderRoute: typeof WeaponsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/grips': {
+      id: '/grips'
+      path: '/grips'
+      fullPath: '/grips'
+      preLoaderRoute: typeof GripsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gems': {
+      id: '/gems'
+      path: '/gems'
+      fullPath: '/gems'
+      preLoaderRoute: typeof GemsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/consumables': {
+      id: '/consumables'
+      path: '/consumables'
+      fullPath: '/consumables'
+      preLoaderRoute: typeof ConsumablesRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/armor': {
+      id: '/armor'
+      path: '/armor'
+      fullPath: '/armor'
+      preLoaderRoute: typeof ArmorRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -254,12 +342,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WeaponsIndexRouteImport
       parentRoute: typeof WeaponsRouteRoute
     }
+    '/grips/': {
+      id: '/grips/'
+      path: '/'
+      fullPath: '/grips/'
+      preLoaderRoute: typeof GripsIndexRouteImport
+      parentRoute: typeof GripsRouteRoute
+    }
+    '/gems/': {
+      id: '/gems/'
+      path: '/'
+      fullPath: '/gems/'
+      preLoaderRoute: typeof GemsIndexRouteImport
+      parentRoute: typeof GemsRouteRoute
+    }
     '/crafting/': {
       id: '/crafting/'
       path: '/crafting'
       fullPath: '/crafting/'
       preLoaderRoute: typeof CraftingIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/consumables/': {
+      id: '/consumables/'
+      path: '/'
+      fullPath: '/consumables/'
+      preLoaderRoute: typeof ConsumablesIndexRouteImport
+      parentRoute: typeof ConsumablesRouteRoute
+    }
+    '/armor/': {
+      id: '/armor/'
+      path: '/'
+      fullPath: '/armor/'
+      preLoaderRoute: typeof ArmorIndexRouteImport
+      parentRoute: typeof ArmorRouteRoute
     }
     '/weapons/$id': {
       id: '/weapons/$id'
@@ -268,8 +384,91 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WeaponsIdRouteImport
       parentRoute: typeof WeaponsRouteRoute
     }
+    '/grips/$id': {
+      id: '/grips/$id'
+      path: '/$id'
+      fullPath: '/grips/$id'
+      preLoaderRoute: typeof GripsIdRouteImport
+      parentRoute: typeof GripsRouteRoute
+    }
+    '/gems/$id': {
+      id: '/gems/$id'
+      path: '/$id'
+      fullPath: '/gems/$id'
+      preLoaderRoute: typeof GemsIdRouteImport
+      parentRoute: typeof GemsRouteRoute
+    }
+    '/consumables/$id': {
+      id: '/consumables/$id'
+      path: '/$id'
+      fullPath: '/consumables/$id'
+      preLoaderRoute: typeof ConsumablesIdRouteImport
+      parentRoute: typeof ConsumablesRouteRoute
+    }
+    '/armor/$id': {
+      id: '/armor/$id'
+      path: '/$id'
+      fullPath: '/armor/$id'
+      preLoaderRoute: typeof ArmorIdRouteImport
+      parentRoute: typeof ArmorRouteRoute
+    }
   }
 }
+
+interface ArmorRouteRouteChildren {
+  ArmorIdRoute: typeof ArmorIdRoute
+  ArmorIndexRoute: typeof ArmorIndexRoute
+}
+
+const ArmorRouteRouteChildren: ArmorRouteRouteChildren = {
+  ArmorIdRoute: ArmorIdRoute,
+  ArmorIndexRoute: ArmorIndexRoute,
+}
+
+const ArmorRouteRouteWithChildren = ArmorRouteRoute._addFileChildren(
+  ArmorRouteRouteChildren,
+)
+
+interface ConsumablesRouteRouteChildren {
+  ConsumablesIdRoute: typeof ConsumablesIdRoute
+  ConsumablesIndexRoute: typeof ConsumablesIndexRoute
+}
+
+const ConsumablesRouteRouteChildren: ConsumablesRouteRouteChildren = {
+  ConsumablesIdRoute: ConsumablesIdRoute,
+  ConsumablesIndexRoute: ConsumablesIndexRoute,
+}
+
+const ConsumablesRouteRouteWithChildren =
+  ConsumablesRouteRoute._addFileChildren(ConsumablesRouteRouteChildren)
+
+interface GemsRouteRouteChildren {
+  GemsIdRoute: typeof GemsIdRoute
+  GemsIndexRoute: typeof GemsIndexRoute
+}
+
+const GemsRouteRouteChildren: GemsRouteRouteChildren = {
+  GemsIdRoute: GemsIdRoute,
+  GemsIndexRoute: GemsIndexRoute,
+}
+
+const GemsRouteRouteWithChildren = GemsRouteRoute._addFileChildren(
+  GemsRouteRouteChildren,
+)
+
+interface GripsRouteRouteChildren {
+  GripsIdRoute: typeof GripsIdRoute
+  GripsIndexRoute: typeof GripsIndexRoute
+}
+
+const GripsRouteRouteChildren: GripsRouteRouteChildren = {
+  GripsIdRoute: GripsIdRoute,
+  GripsIndexRoute: GripsIndexRoute,
+}
+
+const GripsRouteRouteWithChildren = GripsRouteRoute._addFileChildren(
+  GripsRouteRouteChildren,
+)
 
 interface WeaponsRouteRouteChildren {
   WeaponsIdRoute: typeof WeaponsIdRoute
@@ -287,12 +486,12 @@ const WeaponsRouteRouteWithChildren = WeaponsRouteRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ArmorRouteRoute: ArmorRouteRouteWithChildren,
+  ConsumablesRouteRoute: ConsumablesRouteRouteWithChildren,
+  GemsRouteRoute: GemsRouteRouteWithChildren,
+  GripsRouteRoute: GripsRouteRouteWithChildren,
   WeaponsRouteRoute: WeaponsRouteRouteWithChildren,
   SplatRoute: SplatRoute,
-  ArmorRoute: ArmorRoute,
-  ConsumablesRoute: ConsumablesRoute,
-  GemsRoute: GemsRoute,
-  GripsRoute: GripsRoute,
   MaterialGridRoute: MaterialGridRoute,
   MaterialsRoute: MaterialsRoute,
   CraftingIndexRoute: CraftingIndexRoute,

--- a/src/routes/armor.tsx
+++ b/src/routes/armor.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { ArmorPage } from "@/pages/armor/armor-page"
-
-export const Route = createFileRoute("/armor")({
-  component: ArmorPage,
-})

--- a/src/routes/armor/$id.tsx
+++ b/src/routes/armor/$id.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { MaterialSelect } from "@/components/material-select"
+import { StatDisplay } from "@/components/stat-display"
+import { gameApi, fmt } from "@/lib/game-api"
+import { computeEffectiveStats, type ItemStats } from "@/lib/item-stats"
+
+export const Route = createFileRoute("/armor/$id")({
+  component: ArmorDetail,
+})
+
+const ARMOR_MATS = ["Leather", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+const SHIELD_MATS = ["Wood", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+
+function ArmorDetail() {
+  const { id } = Route.useParams()
+  const [material, setMaterial] = useState<string | null>(null)
+
+  const { data: armor = [] } = useQuery({
+    queryKey: ["armor"],
+    queryFn: gameApi.armor,
+  })
+  const { data: materials = [] } = useQuery({
+    queryKey: ["materials"],
+    queryFn: gameApi.materials,
+  })
+
+  const item = armor.find((a) => a.id === Number(id))
+  if (!item) return null
+
+  const materialData = material
+    ? materials.find((m) => m.name === material)
+    : undefined
+  const validMaterials = item.armor_type === "Shield" ? SHIELD_MATS : ARMOR_MATS
+
+  const baseStats: ItemStats = {
+    str: item.str,
+    int: item.int,
+    agi: item.agi,
+    gem_slots: item.gem_slots,
+  }
+
+  const effectiveStats = materialData
+    ? computeEffectiveStats(baseStats, materialData)
+    : baseStats
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/armor"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <div className="bg-muted flex size-32 shrink-0 items-center justify-center rounded-lg">
+              <span className="text-muted-foreground text-xs">Image</span>
+            </div>
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {fmt(item.field_name)}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                {item.armor_type}
+              </p>
+            </div>
+            <div className="w-40">
+              <MaterialSelect
+                materials={validMaterials}
+                value={material}
+                onSelect={setMaterial}
+              />
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col items-center gap-3">
+            <StatDisplay
+              stats={effectiveStats}
+              showAffinities={!!materialData}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/armor/index.tsx
+++ b/src/routes/armor/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/armor/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Armor</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        All armor pieces in Vagrant Story — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/armor/route.tsx
+++ b/src/routes/armor/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { ArmorPage } from "@/pages/armor/armor-page"
+
+export const Route = createFileRoute("/armor")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <ArmorPage />
+    </div>
+  ),
+})

--- a/src/routes/consumables.tsx
+++ b/src/routes/consumables.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { ConsumablesPage } from "@/pages/consumables/consumables-page"
-
-export const Route = createFileRoute("/consumables")({
-  component: ConsumablesPage,
-})

--- a/src/routes/consumables/$id.tsx
+++ b/src/routes/consumables/$id.tsx
@@ -1,0 +1,83 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { gameApi } from "@/lib/game-api"
+
+export const Route = createFileRoute("/consumables/$id")({
+  component: ConsumableDetail,
+})
+
+interface Effect {
+  type: string
+  value: number
+  target: string
+  modifier: string
+}
+
+function formatEffect(e: Effect): string | null {
+  const val = e.value
+  if (typeof val === "string") return `${e.modifier} Random`
+  if (val === 32767) return `${e.modifier} Full`
+  if (val === 0) return null
+  return `${e.modifier} ${val > 0 ? `+${val}` : val}`
+}
+
+function ConsumableDetail() {
+  const { id } = Route.useParams()
+  const { data: consumables = [] } = useQuery({
+    queryKey: ["consumables"],
+    queryFn: gameApi.consumables,
+  })
+
+  const item = consumables.find((c) => c.id === Number(id))
+  if (!item) return null
+
+  const effects = (item.effects as Effect[] | null | undefined) ?? []
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/consumables"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <div className="bg-muted flex size-32 shrink-0 items-center justify-center rounded-lg">
+              <span className="text-muted-foreground text-xs">Image</span>
+            </div>
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {item.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">Consumable</p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col items-center justify-center gap-3">
+            {effects.length > 0 ? (
+              <div className="flex flex-wrap justify-center gap-1.5">
+                {effects.map((e, i) => {
+                  const label = formatEffect(e)
+                  if (!label) return null
+                  return (
+                    <Badge key={i} variant="secondary">
+                      {label}
+                    </Badge>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">No effects</p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/consumables/index.tsx
+++ b/src/routes/consumables/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/consumables/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Consumables</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Items that can be used from inventory — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/consumables/route.tsx
+++ b/src/routes/consumables/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { ConsumablesPage } from "@/pages/consumables/consumables-page"
+
+export const Route = createFileRoute("/consumables")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <ConsumablesPage />
+    </div>
+  ),
+})

--- a/src/routes/gems.tsx
+++ b/src/routes/gems.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { GemsPage } from "@/pages/gems/gems-page"
-
-export const Route = createFileRoute("/gems")({
-  component: GemsPage,
-})

--- a/src/routes/gems/$id.tsx
+++ b/src/routes/gems/$id.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { gameApi, fmt } from "@/lib/game-api"
+import { cn } from "@/lib/utils"
+
+export const Route = createFileRoute("/gems/$id")({
+  component: GemDetail,
+})
+
+function GemDetail() {
+  const { id } = Route.useParams()
+  const { data: gems = [] } = useQuery({
+    queryKey: ["gems"],
+    queryFn: gameApi.gems,
+  })
+
+  const gem = gems.find((g) => g.id === Number(id))
+  if (!gem) return null
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/gems"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <div className="bg-muted flex size-32 shrink-0 items-center justify-center rounded-lg">
+              <span className="text-muted-foreground text-xs">Image</span>
+            </div>
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {fmt(gem.field_name)}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">Gem</p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col items-center justify-center gap-3">
+            <div className="bg-muted/50 flex flex-col items-center rounded px-4 py-2">
+              <span className="text-muted-foreground text-xs">Affinity</span>
+              <span className="text-sm font-medium">{gem.affinity_type}</span>
+            </div>
+            <div className="bg-muted/50 flex flex-col items-center rounded px-4 py-2">
+              <span className="text-muted-foreground text-xs">Magnitude</span>
+              <span
+                className={cn(
+                  "text-sm font-medium",
+                  gem.magnitude > 0 ? "text-green-400" : "text-muted-foreground"
+                )}
+              >
+                {gem.magnitude > 0 ? `+${gem.magnitude}` : gem.magnitude}
+              </span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/gems/index.tsx
+++ b/src/routes/gems/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/gems/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Gems</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Gems can be attached to equipment with gem slots — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/gems/route.tsx
+++ b/src/routes/gems/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { GemsPage } from "@/pages/gems/gems-page"
+
+export const Route = createFileRoute("/gems")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <GemsPage />
+    </div>
+  ),
+})

--- a/src/routes/grips.tsx
+++ b/src/routes/grips.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { GripsPage } from "@/pages/grips/grips-page"
-
-export const Route = createFileRoute("/grips")({
-  component: GripsPage,
-})

--- a/src/routes/grips/$id.tsx
+++ b/src/routes/grips/$id.tsx
@@ -1,0 +1,78 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { gameApi, fmt } from "@/lib/game-api"
+import { cn } from "@/lib/utils"
+
+export const Route = createFileRoute("/grips/$id")({
+  component: GripDetail,
+})
+
+function GripDetail() {
+  const { id } = Route.useParams()
+  const { data: grips = [] } = useQuery({
+    queryKey: ["grips"],
+    queryFn: gameApi.grips,
+  })
+
+  const grip = grips.find((g) => g.id === Number(id))
+  if (!grip) return null
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/grips"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <div className="bg-muted flex size-32 shrink-0 items-center justify-center rounded-lg">
+              <span className="text-muted-foreground text-xs">Image</span>
+            </div>
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {fmt(grip.field_name)}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                {grip.grip_type}
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col items-center justify-center gap-3">
+            <div className="flex flex-wrap justify-center gap-2">
+              <StatBox label="STR" value={grip.str} />
+              <StatBox label="INT" value={grip.int} />
+              <StatBox label="AGI" value={grip.agi} />
+              {grip.dp != null && <StatBox label="DP" value={grip.dp} />}
+              {grip.pp != null && <StatBox label="PP" value={grip.pp} />}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function StatBox({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="bg-muted/50 flex min-w-12 flex-col items-center rounded px-2.5 py-1.5">
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <span
+        className={cn(
+          "text-sm font-medium",
+          value > 0 && "text-green-400",
+          value < 0 && "text-red-400",
+          value === 0 && "text-muted-foreground"
+        )}
+      >
+        {value > 0 ? `+${value}` : value}
+      </span>
+    </div>
+  )
+}

--- a/src/routes/grips/index.tsx
+++ b/src/routes/grips/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/grips/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Grips</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Grips modify weapon stats and can be swapped — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/grips/route.tsx
+++ b/src/routes/grips/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { GripsPage } from "@/pages/grips/grips-page"
+
+export const Route = createFileRoute("/grips")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <GripsPage />
+    </div>
+  ),
+})

--- a/src/routes/weapons.tsx
+++ b/src/routes/weapons.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { WeaponsPage } from "@/pages/weapons/weapons-page"
-
-export const Route = createFileRoute("/weapons")({
-  component: WeaponsPage,
-})

--- a/src/routes/weapons/$id.tsx
+++ b/src/routes/weapons/$id.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { MaterialSelect } from "@/components/material-select"
+import { StatDisplay } from "@/components/stat-display"
+import { gameApi, fmt } from "@/lib/game-api"
+import { computeEffectiveStats, type ItemStats } from "@/lib/item-stats"
+
+export const Route = createFileRoute("/weapons/$id")({
+  component: WeaponDetail,
+})
+
+const WEAPON_HANDS: Record<string, string> = {
+  Dagger: "1H",
+  Sword: "1H",
+  Axe: "1H",
+  Mace: "1H",
+  "Great Sword": "2H",
+  "Great Axe": "2H",
+  "Heavy Mace": "2H",
+  Polearm: "2H",
+  Staff: "2H",
+  Crossbow: "2H",
+}
+
+const BLADE_MATS = ["Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+
+function WeaponDetail() {
+  const { id } = Route.useParams()
+  const [material, setMaterial] = useState<string | null>(null)
+
+  const { data: weapons = [] } = useQuery({
+    queryKey: ["weapons"],
+    queryFn: gameApi.weapons,
+  })
+  const { data: materials = [] } = useQuery({
+    queryKey: ["materials"],
+    queryFn: gameApi.materials,
+  })
+
+  const weapon = weapons.find((w) => w.id === Number(id))
+  if (!weapon) return null
+
+  const hands = WEAPON_HANDS[weapon.blade_type]
+  const materialData = material
+    ? materials.find((m) => m.name === material)
+    : undefined
+
+  const baseStats: ItemStats = {
+    str: weapon.str,
+    int: weapon.int,
+    agi: weapon.agi,
+    range: weapon.range,
+    damage: weapon.damage,
+    risk: weapon.risk,
+    damage_type: weapon.damage_type,
+  }
+
+  const effectiveStats =
+    baseStats && materialData
+      ? computeEffectiveStats(baseStats, materialData)
+      : baseStats
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/weapons"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          {/* Left: image, name, type, material */}
+          <div className="flex flex-col items-center gap-3">
+            <div className="bg-muted flex size-32 shrink-0 items-center justify-center rounded-lg">
+              <span className="text-muted-foreground text-xs">Image</span>
+            </div>
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {fmt(weapon.field_name)}
+              </h2>
+              <div className="text-muted-foreground mt-0.5 flex items-center justify-center gap-2 text-sm">
+                <span>{weapon.blade_type}</span>
+                {hands && (
+                  <>
+                    <span>·</span>
+                    <span>{hands}</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div className="w-40">
+              <MaterialSelect
+                materials={BLADE_MATS}
+                value={material}
+                onSelect={setMaterial}
+              />
+            </div>
+          </div>
+
+          {/* Right: damage type, stats, affinities */}
+          <div className="flex flex-1 flex-col items-center gap-3">
+            <StatDisplay
+              stats={effectiveStats}
+              showAffinities={!!materialData}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/weapons/index.tsx
+++ b/src/routes/weapons/index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/weapons/")({
+  component: WeaponsIndex,
+})
+
+function WeaponsIndex() {
+  return (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Weapons</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        All blades in Vagrant Story — click a weapon for details
+      </p>
+    </div>
+  )
+}

--- a/src/routes/weapons/route.tsx
+++ b/src/routes/weapons/route.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { WeaponsPage } from "@/pages/weapons/weapons-page"
+
+export const Route = createFileRoute("/weapons")({
+  component: WeaponsLayout,
+})
+
+function WeaponsLayout() {
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <WeaponsPage />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Clickable table rows navigate to /:type/:id, showing a detail hero above the table.

**All item types:**
- Weapons: hero with material select (Bronze–Damascus), damage type, stats + affinities
- Armor: hero with material select (Leather–Damascus / Wood–Damascus for shields), stats + affinities
- Gems: hero with affinity type and magnitude
- Grips: hero with STR/INT/AGI/DP/PP stats
- Consumables: hero with effect badges

**DataTable improvements:**
- Pagination (10/25/50/100 rows per page)
- First/last page buttons
- Fixed column widths (table-fixed)
- Clickable rows via getRowLink prop

## Test plan
- [ ] Click weapon row → hero shows with stats, material select works
- [ ] Click armor row → hero shows, shield vs armor materials correct
- [ ] Click gem/grip/consumable → hero shows appropriate details
- [ ] Pagination controls work (prev/next/first/last, rows dropdown)
- [ ] Direct URL /weapons/5 works (deep link)
- [ ] X button returns to list view