### PR TITLE
Display gem stats and consumable descriptions from API

### DIFF
--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -74,8 +74,26 @@ export interface Gem {
   field_name: string
   name: string
   description_fr?: string
-  magnitude: number
+  description?: string
+  magnitude: string
   affinity_type: string
+  gem_type?: string
+  str: number
+  int: number
+  agi: number
+  human: number
+  beast: number
+  undead: number
+  phantom: number
+  dragon: number
+  evil: number
+  physical: number
+  fire: number
+  water: number
+  wind: number
+  earth: number
+  light: number
+  dark: number
 }
 
 export interface Grip {
@@ -98,6 +116,7 @@ export interface Consumable {
   field_name: string
   name: string
   description_fr?: string
+  description?: string
   effects?: unknown
 }
 

--- a/src/pages/consumables/consumables-page.tsx
+++ b/src/pages/consumables/consumables-page.tsx
@@ -1,27 +1,9 @@
 import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { type ColumnDef } from "@tanstack/react-table"
-import { Badge } from "@/components/ui/badge"
 import { ItemIcon } from "@/components/item-icon"
 import { DataTable } from "@/components/data-table"
 import { gameApi, type Consumable } from "@/lib/game-api"
-
-interface Effect {
-  type: string
-  value: number
-  target: string
-  modifier: string
-}
-
-function formatEffect(e: Effect): string | null {
-  const val = e.value
-  // Broken C# parse artifacts
-  if (typeof val === "string") return `${e.modifier} Random`
-  // 32767 = max int16, means full restore
-  if (val === 32767) return `${e.modifier} Full`
-  if (val === 0) return null
-  return `${e.modifier} ${val > 0 ? `+${val}` : val}`
-}
 
 const columns: ColumnDef<Consumable>[] = [
   {
@@ -35,26 +17,12 @@ const columns: ColumnDef<Consumable>[] = [
     ),
   },
   {
-    id: "effects",
-    header: "Effects",
+    accessorKey: "description",
+    header: "Effect",
     cell: ({ row }) => {
-      const effects = row.original.effects as Effect[] | null | undefined
-      if (!effects || !Array.isArray(effects) || effects.length === 0) {
-        return <span className="text-muted-foreground">-</span>
-      }
-      return (
-        <div className="flex flex-wrap gap-1">
-          {effects.map((e, i) => {
-            const label = formatEffect(e)
-            if (!label) return null
-            return (
-              <Badge key={i} variant="secondary" className="text-xs">
-                {label}
-              </Badge>
-            )
-          })}
-        </div>
-      )
+      const desc = row.original.description
+      if (!desc) return <span className="text-muted-foreground">-</span>
+      return <span className="text-sm">{desc}</span>
     },
     enableSorting: false,
   },

--- a/src/pages/crafting/crafting-page.tsx
+++ b/src/pages/crafting/crafting-page.tsx
@@ -84,7 +84,6 @@ const ARMOR_MATS = ["Leather", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
 const SHIELD_MATS = ["Wood", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
 
 // Maps API blade_type → material recipe input type.
-// Only needed for types where the names differ.
 const MATERIAL_TYPE_MAP: Record<string, string> = {
   "Axe / Mace": "AxeMace",
 }

--- a/src/pages/gems/gems-page.tsx
+++ b/src/pages/gems/gems-page.tsx
@@ -1,9 +1,18 @@
 import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable, type ColumnFilter } from "@/components/data-table"
 import { ItemIcon } from "@/components/item-icon"
-import { DataTable } from "@/components/data-table"
 import { gameApi, fmt, type Gem } from "@/lib/game-api"
+
+function StatCell({ value }: { value: number }) {
+  if (value === 0) return <span className="text-muted-foreground">0</span>
+  return (
+    <span className={value > 0 ? "text-green-400" : "text-red-400"}>
+      {value > 0 ? `+${value}` : value}
+    </span>
+  )
+}
 
 const columns: ColumnDef<Gem>[] = [
   {
@@ -16,8 +25,30 @@ const columns: ColumnDef<Gem>[] = [
       </div>
     ),
   },
-  { accessorKey: "affinity_type", header: "Affinity" },
-  { accessorKey: "magnitude", header: "Magnitude" },
+  {
+    accessorKey: "gem_type",
+    header: "Type",
+    filterFn: "equals",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return v || <span className="text-muted-foreground">-</span>
+    },
+  },
+  {
+    accessorKey: "str",
+    header: "STR",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "int",
+    header: "INT",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "agi",
+    header: "AGI",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
 ]
 
 export function GemsPage() {
@@ -31,12 +62,20 @@ export function GemsPage() {
     [data]
   )
 
+  const typeFilters = useMemo<ColumnFilter[]>(() => {
+    const types = [
+      ...new Set(data.map((g) => g.gem_type).filter(Boolean)),
+    ].sort() as string[]
+    return [{ column: "gem_type", label: "Type", options: types }]
+  }, [data])
+
   return (
     <DataTable
       data={enriched}
       columns={columns}
       searchPlaceholder="Search gems..."
       isLoading={isLoading}
+      filters={typeFilters}
       getRowLink={(row) => ({
         to: "/gems/$id",
         params: { id: String(row.original.id) },

--- a/src/routes/consumables/$id.tsx
+++ b/src/routes/consumables/$id.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
 import { gameApi } from "@/lib/game-api"
@@ -9,21 +8,6 @@ import { gameApi } from "@/lib/game-api"
 export const Route = createFileRoute("/consumables/$id")({
   component: ConsumableDetail,
 })
-
-interface Effect {
-  type: string
-  value: number
-  target: string
-  modifier: string
-}
-
-function formatEffect(e: Effect): string | null {
-  const val = e.value
-  if (typeof val === "string") return `${e.modifier} Random`
-  if (val === 32767) return `${e.modifier} Full`
-  if (val === 0) return null
-  return `${e.modifier} ${val > 0 ? `+${val}` : val}`
-}
 
 function ConsumableDetail() {
   const { id } = Route.useParams()
@@ -34,8 +18,6 @@ function ConsumableDetail() {
 
   const item = consumables.find((c) => c.id === Number(id))
   if (!item) return null
-
-  const effects = (item.effects as Effect[] | null | undefined) ?? []
 
   return (
     <Card className="border-primary/30 mx-auto max-w-3xl">
@@ -50,7 +32,7 @@ function ConsumableDetail() {
         </div>
         <div className="flex gap-6">
           <div className="flex flex-col items-center gap-3">
-            <ItemIcon type={"Gem"} size="lg" className="rounded-lg" />
+            <ItemIcon type="Consumable" size="lg" className="rounded-lg" />
             <div className="text-center">
               <h2 className="text-2xl font-medium tracking-wide">
                 {item.name}
@@ -59,20 +41,12 @@ function ConsumableDetail() {
             </div>
           </div>
           <div className="flex flex-1 flex-col items-center justify-center gap-3">
-            {effects.length > 0 ? (
-              <div className="flex flex-wrap justify-center gap-1.5">
-                {effects.map((e, i) => {
-                  const label = formatEffect(e)
-                  if (!label) return null
-                  return (
-                    <Badge key={i} variant="secondary">
-                      {label}
-                    </Badge>
-                  )
-                })}
-              </div>
+            {item.description ? (
+              <p className="text-center text-sm">{item.description}</p>
             ) : (
-              <p className="text-muted-foreground text-sm">No effects</p>
+              <p className="text-muted-foreground text-sm">
+                No description available
+              </p>
             )}
           </div>
         </div>

--- a/src/routes/gems/$id.tsx
+++ b/src/routes/gems/$id.tsx
@@ -3,8 +3,9 @@ import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
+import { StatDisplay } from "@/components/stat-display"
 import { gameApi, fmt } from "@/lib/game-api"
-import { cn } from "@/lib/utils"
+import type { ItemStats } from "@/lib/item-stats"
 
 export const Route = createFileRoute("/gems/$id")({
   component: GemDetail,
@@ -20,6 +21,28 @@ function GemDetail() {
   const gem = gems.find((g) => g.id === Number(id))
   if (!gem) return null
 
+  const stats: ItemStats & Record<string, number> = {
+    str: gem.str,
+    int: gem.int,
+    agi: gem.agi,
+    human: gem.human,
+    beast: gem.beast,
+    undead: gem.undead,
+    phantom: gem.phantom,
+    dragon: gem.dragon,
+    evil: gem.evil,
+    fire: gem.fire,
+    water: gem.water,
+    wind: gem.wind,
+    earth: gem.earth,
+    light: gem.light,
+    dark: gem.dark,
+  }
+
+  const hasAffinities = Object.entries(stats).some(
+    ([k, v]) => !["str", "int", "agi"].includes(k) && v !== 0
+  )
+
   return (
     <Card className="border-primary/30 mx-auto max-w-3xl">
       <CardContent className="pt-6">
@@ -33,30 +56,23 @@ function GemDetail() {
         </div>
         <div className="flex gap-6">
           <div className="flex flex-col items-center gap-3">
-            <ItemIcon type={"Gem"} size="lg" className="rounded-lg" />
+            <ItemIcon type="Gem" size="lg" className="rounded-lg" />
             <div className="text-center">
               <h2 className="text-2xl font-medium tracking-wide">
                 {fmt(gem.field_name)}
               </h2>
-              <p className="text-muted-foreground mt-0.5 text-sm">Gem</p>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                {gem.gem_type ? `${gem.gem_type} Gem` : "Gem"}
+              </p>
             </div>
           </div>
-          <div className="flex flex-1 flex-col items-center justify-center gap-3">
-            <div className="bg-muted/50 flex flex-col items-center rounded px-4 py-2">
-              <span className="text-muted-foreground text-xs">Affinity</span>
-              <span className="text-sm font-medium">{gem.affinity_type}</span>
-            </div>
-            <div className="bg-muted/50 flex flex-col items-center rounded px-4 py-2">
-              <span className="text-muted-foreground text-xs">Magnitude</span>
-              <span
-                className={cn(
-                  "text-sm font-medium",
-                  gem.magnitude > 0 ? "text-green-400" : "text-muted-foreground"
-                )}
-              >
-                {gem.magnitude > 0 ? `+${gem.magnitude}` : gem.magnitude}
-              </span>
-            </div>
+          <div className="flex flex-1 flex-col items-center gap-3">
+            <StatDisplay stats={stats} showAffinities={hasAffinities} />
+            {gem.description && (
+              <p className="text-muted-foreground mt-2 text-center text-sm italic">
+                {gem.description}
+              </p>
+            )}
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
Update frontend to use the new gem and consumable data from the API.

- Gems page: show gem_type, STR/INT/AGI stats, type filter dropdown
- Gem hero: full stat display with class and elemental affinities, description
- Consumables page: show description column instead of broken effects JSON
- Consumable hero: show description text
- Update Gem and Consumable TypeScript interfaces for new API fields