### PR TITLE
Add full stat columns to accessories and gems tables

### DIFF
--- a/src/pages/accessories/accessories-page.tsx
+++ b/src/pages/accessories/accessories-page.tsx
@@ -5,6 +5,15 @@ import { ItemIcon } from "@/components/item-icon"
 import { DataTable } from "@/components/data-table"
 import { gameApi, fmt, type Armor } from "@/lib/game-api"
 
+function StatCell({ value }: { value: number }) {
+  if (value === 0) return <span className="text-muted-foreground">0</span>
+  return (
+    <span className={value > 0 ? "text-green-400" : "text-red-400"}>
+      {value > 0 ? `+${value}` : value}
+    </span>
+  )
+}
+
 const columns: ColumnDef<Armor>[] = [
   {
     accessorKey: "field_name",
@@ -29,6 +38,86 @@ const columns: ColumnDef<Armor>[] = [
   {
     accessorKey: "agi",
     header: "AGI",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "blunt",
+    header: "Blunt",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "edged",
+    header: "Edged",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "piercing",
+    header: "Pierce",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "physical",
+    header: "Phys",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "human",
+    header: "Hum",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "beast",
+    header: "Bst",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "undead",
+    header: "Und",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "phantom",
+    header: "Phm",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "dragon",
+    header: "Drg",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "evil",
+    header: "Evl",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "fire",
+    header: "Fir",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "water",
+    header: "Wat",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "wind",
+    header: "Wnd",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "earth",
+    header: "Ear",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "light",
+    header: "Lit",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "dark",
+    header: "Drk",
     cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
   },
 ]
@@ -58,14 +147,5 @@ export function AccessoriesPage() {
         params: { id: String(row.original.id) },
       })}
     />
-  )
-}
-
-function StatCell({ value }: { value: number }) {
-  if (value === 0) return <span className="text-muted-foreground">0</span>
-  return (
-    <span className={value > 0 ? "text-green-400" : "text-red-400"}>
-      {value > 0 ? `+${value}` : value}
-    </span>
   )
 }

--- a/src/pages/gems/gems-page.tsx
+++ b/src/pages/gems/gems-page.tsx
@@ -49,6 +49,36 @@ const columns: ColumnDef<Gem>[] = [
     header: "AGI",
     cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
   },
+  {
+    accessorKey: "human",
+    header: "Hum",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "beast",
+    header: "Bst",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "undead",
+    header: "Und",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "phantom",
+    header: "Phm",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "dragon",
+    header: "Drg",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
+  {
+    accessorKey: "evil",
+    header: "Evl",
+    cell: ({ getValue }) => <StatCell value={getValue<number>()} />,
+  },
 ]
 
 export function GemsPage() {


### PR DESCRIPTION
All stat columns from the API now visible in the tables.