### PR TITLE
feat: add spells page with category filter

### DIFF
--- a/src/components/item-icon.tsx
+++ b/src/components/item-icon.tsx
@@ -26,6 +26,11 @@ const ICON_MAP: Record<string, string> = {
   Grip: "Grip",
   Consumable: "Consumable",
   Material: "Material",
+  Spell: "Gem",
+  Key: "Consumable",
+  Sigil: "Consumable",
+  Grimoire: "Consumable",
+  Workshop: "Material",
 }
 
 interface ItemIconProps {

--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -125,6 +125,17 @@ export interface Consumable {
   effects?: unknown
 }
 
+export interface Spell {
+  id: number
+  name: string
+  category: string
+  mp_cost: string
+  targeting: string
+  affinity: string
+  effect: string
+  grimoire: string
+}
+
 export interface CraftingRecipe {
   id: number
   category: string
@@ -163,6 +174,8 @@ export const gameApi = {
   gems: () => fetchApi<Gem[]>("/gems?limit=200"),
   grips: () => fetchApi<Grip[]>("/grips?limit=200"),
   consumables: () => fetchApi<Consumable[]>("/consumables?limit=200"),
+  spells: () => fetchApi<Spell[]>("/spells?limit=200"),
+  spell: (id: number) => fetchApi<Spell>(`/spells/${id}`),
   craftingRecipes: (params?: string) =>
     fetchApi<CraftingRecipe[]>(
       `/crafting-recipes${params ? `?${params}` : "?limit=200"}`

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -26,6 +26,10 @@ export function HomePage() {
     queryKey: ["consumables"],
     queryFn: gameApi.consumables,
   })
+  const { data: spells = [] } = useQuery({
+    queryKey: ["spells"],
+    queryFn: gameApi.spells,
+  })
   const { data: materials = [] } = useQuery({
     queryKey: ["materials"],
     queryFn: gameApi.materials,
@@ -71,6 +75,12 @@ export function HomePage() {
       label: "Consumables",
       icon: "Consumable",
       count: consumables.length,
+    },
+    {
+      to: "/spells" as const,
+      label: "Spells",
+      icon: "Spell",
+      count: spells.length,
     },
   ]
 

--- a/src/pages/spells/spells-page.tsx
+++ b/src/pages/spells/spells-page.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable, type ColumnFilter } from "@/components/data-table"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi, type Spell } from "@/lib/game-api"
+
+const columns: ColumnDef<Spell>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <ItemIcon type="Spell" />
+        <span className="font-medium">{row.original.name}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "category",
+    header: "Category",
+    filterFn: "equals",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "mp_cost",
+    header: "MP",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-primary text-sm font-medium">{v}</span>
+    },
+  },
+  {
+    accessorKey: "affinity",
+    header: "Affinity",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      if (!v || v === "None")
+        return <span className="text-muted-foreground">-</span>
+      return <span className="text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "targeting",
+    header: "Target",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-muted-foreground text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "effect",
+    header: "Effect",
+    enableSorting: false,
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return (
+        <span className="text-muted-foreground line-clamp-1 text-sm">{v}</span>
+      )
+    },
+  },
+]
+
+export function SpellsPage() {
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["spells"],
+    queryFn: gameApi.spells,
+  })
+
+  const enriched = useMemo(
+    () => data.map((s) => ({ ...s, _display: s.name })),
+    [data]
+  )
+
+  const categoryFilters = useMemo<ColumnFilter[]>(() => {
+    const categories = [
+      ...new Set(data.map((s) => s.category).filter(Boolean)),
+    ].sort()
+    return [{ column: "category", label: "Category", options: categories }]
+  }, [data])
+
+  return (
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search spells..."
+      isLoading={isLoading}
+      filters={categoryFilters}
+      getRowLink={(row) => ({
+        to: "/spells/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
+  )
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -59,6 +59,7 @@ const ITEM_LINKS = [
   { to: "/accessories" as const, label: "Accessories" },
   { to: "/gems" as const, label: "Gems" },
   { to: "/consumables" as const, label: "Consumables" },
+  { to: "/spells" as const, label: "Spells" },
 ]
 
 const NAV_TABS = [
@@ -69,6 +70,7 @@ const NAV_TABS = [
   { to: "/accessories" as const, label: "Accessories" },
   { to: "/gems" as const, label: "Gems" },
   { to: "/consumables" as const, label: "Consumables" },
+  { to: "/spells" as const, label: "Spells" },
   { to: "/crafting" as const, label: "Crafting" },
   { to: "/material-grid" as const, label: "Material Grid" },
 ]

--- a/src/routes/spells/$id.tsx
+++ b/src/routes/spells/$id.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi } from "@/lib/game-api"
+
+export const Route = createFileRoute("/spells/$id")({
+  component: SpellDetail,
+})
+
+function SpellDetail() {
+  const { id } = Route.useParams()
+  const { data: spells = [] } = useQuery({
+    queryKey: ["spells"],
+    queryFn: gameApi.spells,
+  })
+
+  const spell = spells.find((s) => s.id === Number(id))
+  if (!spell) return null
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/spells"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <ItemIcon type="Spell" size="lg" className="rounded-lg" />
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {spell.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                {spell.category} Spell
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-4">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="secondary">{spell.mp_cost} MP</Badge>
+              {spell.affinity && spell.affinity !== "None" && (
+                <Badge variant="outline">{spell.affinity}</Badge>
+              )}
+              <Badge variant="outline">{spell.targeting}</Badge>
+            </div>
+            <p className="text-sm">{spell.effect}</p>
+            {spell.grimoire && (
+              <p className="text-muted-foreground text-sm">
+                <span className="font-medium">Grimoire:</span> {spell.grimoire}
+              </p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/spells/index.tsx
+++ b/src/routes/spells/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/spells/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Spells</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Magic spells organized by school — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/spells/route.tsx
+++ b/src/routes/spells/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { SpellsPage } from "@/pages/spells/spells-page"
+
+export const Route = createFileRoute("/spells")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <SpellsPage />
+    </div>
+  ),
+})


### PR DESCRIPTION
## Summary
- New spells page with DataTable, category filter (Warlock/Shaman/Sorcerer/Enchanter), and detail hero card
- Shows MP cost, affinity, targeting type, effect, and grimoire name
- Added to nav tabs, items dropdown, and homepage database cards
- Mapped Spell icon type in item-icon component

## Test plan
- [ ] /spells page loads and shows all spells
- [ ] Category filter works for each spell school
- [ ] Click on a spell shows detail card with all fields
- [ ] Nav tabs include Spells
- [ ] Homepage shows Spells card with count

Closes #16