### PR TITLE
feat: add keys page with detail view

### DIFF
--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -136,6 +136,15 @@ export interface Spell {
   grimoire: string
 }
 
+export interface Key {
+  id: number
+  name: string
+  area: string
+  room: string
+  source: string
+  locations_used: string
+}
+
 export interface CraftingRecipe {
   id: number
   category: string
@@ -176,6 +185,7 @@ export const gameApi = {
   consumables: () => fetchApi<Consumable[]>("/consumables?limit=200"),
   spells: () => fetchApi<Spell[]>("/spells?limit=200"),
   spell: (id: number) => fetchApi<Spell>(`/spells/${id}`),
+  keys: () => fetchApi<Key[]>("/keys?limit=200"),
   craftingRecipes: (params?: string) =>
     fetchApi<CraftingRecipe[]>(
       `/crafting-recipes${params ? `?${params}` : "?limit=200"}`

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -30,6 +30,10 @@ export function HomePage() {
     queryKey: ["spells"],
     queryFn: gameApi.spells,
   })
+  const { data: keys = [] } = useQuery({
+    queryKey: ["keys"],
+    queryFn: gameApi.keys,
+  })
   const { data: materials = [] } = useQuery({
     queryKey: ["materials"],
     queryFn: gameApi.materials,
@@ -81,6 +85,12 @@ export function HomePage() {
       label: "Spells",
       icon: "Spell",
       count: spells.length,
+    },
+    {
+      to: "/keys" as const,
+      label: "Keys",
+      icon: "Key",
+      count: keys.length,
     },
   ]
 

--- a/src/pages/keys/keys-page.tsx
+++ b/src/pages/keys/keys-page.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable } from "@/components/data-table"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi, type Key } from "@/lib/game-api"
+
+const columns: ColumnDef<Key>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <ItemIcon type="Key" />
+        <span className="font-medium">{row.original.name}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "area",
+    header: "Area",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "source",
+    header: "Source",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-muted-foreground text-sm">{v}</span>
+    },
+  },
+]
+
+export function KeysPage() {
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["keys"],
+    queryFn: gameApi.keys,
+  })
+
+  const enriched = useMemo(
+    () => data.map((k) => ({ ...k, _display: k.name })),
+    [data]
+  )
+
+  return (
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search keys..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/keys/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,8 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as MaterialsRouteImport } from './routes/materials'
 import { Route as MaterialGridRouteImport } from './routes/material-grid'
 import { Route as WeaponsRouteRouteImport } from './routes/weapons/route'
+import { Route as SpellsRouteRouteImport } from './routes/spells/route'
+import { Route as KeysRouteRouteImport } from './routes/keys/route'
 import { Route as GripsRouteRouteImport } from './routes/grips/route'
 import { Route as GemsRouteRouteImport } from './routes/gems/route'
 import { Route as ConsumablesRouteRouteImport } from './routes/consumables/route'
@@ -19,6 +21,8 @@ import { Route as ArmorRouteRouteImport } from './routes/armor/route'
 import { Route as AccessoriesRouteRouteImport } from './routes/accessories/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WeaponsIndexRouteImport } from './routes/weapons/index'
+import { Route as SpellsIndexRouteImport } from './routes/spells/index'
+import { Route as KeysIndexRouteImport } from './routes/keys/index'
 import { Route as GripsIndexRouteImport } from './routes/grips/index'
 import { Route as GemsIndexRouteImport } from './routes/gems/index'
 import { Route as CraftingIndexRouteImport } from './routes/crafting/index'
@@ -26,6 +30,8 @@ import { Route as ConsumablesIndexRouteImport } from './routes/consumables/index
 import { Route as ArmorIndexRouteImport } from './routes/armor/index'
 import { Route as AccessoriesIndexRouteImport } from './routes/accessories/index'
 import { Route as WeaponsIdRouteImport } from './routes/weapons/$id'
+import { Route as SpellsIdRouteImport } from './routes/spells/$id'
+import { Route as KeysIdRouteImport } from './routes/keys/$id'
 import { Route as GripsIdRouteImport } from './routes/grips/$id'
 import { Route as GemsIdRouteImport } from './routes/gems/$id'
 import { Route as ConsumablesIdRouteImport } from './routes/consumables/$id'
@@ -45,6 +51,16 @@ const MaterialGridRoute = MaterialGridRouteImport.update({
 const WeaponsRouteRoute = WeaponsRouteRouteImport.update({
   id: '/weapons',
   path: '/weapons',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SpellsRouteRoute = SpellsRouteRouteImport.update({
+  id: '/spells',
+  path: '/spells',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const KeysRouteRoute = KeysRouteRouteImport.update({
+  id: '/keys',
+  path: '/keys',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GripsRouteRoute = GripsRouteRouteImport.update({
@@ -82,6 +98,16 @@ const WeaponsIndexRoute = WeaponsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => WeaponsRouteRoute,
 } as any)
+const SpellsIndexRoute = SpellsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => SpellsRouteRoute,
+} as any)
+const KeysIndexRoute = KeysIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => KeysRouteRoute,
+} as any)
 const GripsIndexRoute = GripsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -117,6 +143,16 @@ const WeaponsIdRoute = WeaponsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => WeaponsRouteRoute,
 } as any)
+const SpellsIdRoute = SpellsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => SpellsRouteRoute,
+} as any)
+const KeysIdRoute = KeysIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => KeysRouteRoute,
+} as any)
 const GripsIdRoute = GripsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -150,6 +186,8 @@ export interface FileRoutesByFullPath {
   '/consumables': typeof ConsumablesRouteRouteWithChildren
   '/gems': typeof GemsRouteRouteWithChildren
   '/grips': typeof GripsRouteRouteWithChildren
+  '/keys': typeof KeysRouteRouteWithChildren
+  '/spells': typeof SpellsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
@@ -158,6 +196,8 @@ export interface FileRoutesByFullPath {
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
   '/grips/$id': typeof GripsIdRoute
+  '/keys/$id': typeof KeysIdRoute
+  '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
   '/armor/': typeof ArmorIndexRoute
@@ -165,6 +205,8 @@ export interface FileRoutesByFullPath {
   '/crafting/': typeof CraftingIndexRoute
   '/gems/': typeof GemsIndexRoute
   '/grips/': typeof GripsIndexRoute
+  '/keys/': typeof KeysIndexRoute
+  '/spells/': typeof SpellsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
 }
 export interface FileRoutesByTo {
@@ -176,6 +218,8 @@ export interface FileRoutesByTo {
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
   '/grips/$id': typeof GripsIdRoute
+  '/keys/$id': typeof KeysIdRoute
+  '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
   '/accessories': typeof AccessoriesIndexRoute
   '/armor': typeof ArmorIndexRoute
@@ -183,6 +227,8 @@ export interface FileRoutesByTo {
   '/crafting': typeof CraftingIndexRoute
   '/gems': typeof GemsIndexRoute
   '/grips': typeof GripsIndexRoute
+  '/keys': typeof KeysIndexRoute
+  '/spells': typeof SpellsIndexRoute
   '/weapons': typeof WeaponsIndexRoute
 }
 export interface FileRoutesById {
@@ -193,6 +239,8 @@ export interface FileRoutesById {
   '/consumables': typeof ConsumablesRouteRouteWithChildren
   '/gems': typeof GemsRouteRouteWithChildren
   '/grips': typeof GripsRouteRouteWithChildren
+  '/keys': typeof KeysRouteRouteWithChildren
+  '/spells': typeof SpellsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
@@ -201,6 +249,8 @@ export interface FileRoutesById {
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
   '/grips/$id': typeof GripsIdRoute
+  '/keys/$id': typeof KeysIdRoute
+  '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
   '/armor/': typeof ArmorIndexRoute
@@ -208,6 +258,8 @@ export interface FileRoutesById {
   '/crafting/': typeof CraftingIndexRoute
   '/gems/': typeof GemsIndexRoute
   '/grips/': typeof GripsIndexRoute
+  '/keys/': typeof KeysIndexRoute
+  '/spells/': typeof SpellsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
 }
 export interface FileRouteTypes {
@@ -219,6 +271,8 @@ export interface FileRouteTypes {
     | '/consumables'
     | '/gems'
     | '/grips'
+    | '/keys'
+    | '/spells'
     | '/weapons'
     | '/material-grid'
     | '/materials'
@@ -227,6 +281,8 @@ export interface FileRouteTypes {
     | '/consumables/$id'
     | '/gems/$id'
     | '/grips/$id'
+    | '/keys/$id'
+    | '/spells/$id'
     | '/weapons/$id'
     | '/accessories/'
     | '/armor/'
@@ -234,6 +290,8 @@ export interface FileRouteTypes {
     | '/crafting/'
     | '/gems/'
     | '/grips/'
+    | '/keys/'
+    | '/spells/'
     | '/weapons/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -245,6 +303,8 @@ export interface FileRouteTypes {
     | '/consumables/$id'
     | '/gems/$id'
     | '/grips/$id'
+    | '/keys/$id'
+    | '/spells/$id'
     | '/weapons/$id'
     | '/accessories'
     | '/armor'
@@ -252,6 +312,8 @@ export interface FileRouteTypes {
     | '/crafting'
     | '/gems'
     | '/grips'
+    | '/keys'
+    | '/spells'
     | '/weapons'
   id:
     | '__root__'
@@ -261,6 +323,8 @@ export interface FileRouteTypes {
     | '/consumables'
     | '/gems'
     | '/grips'
+    | '/keys'
+    | '/spells'
     | '/weapons'
     | '/material-grid'
     | '/materials'
@@ -269,6 +333,8 @@ export interface FileRouteTypes {
     | '/consumables/$id'
     | '/gems/$id'
     | '/grips/$id'
+    | '/keys/$id'
+    | '/spells/$id'
     | '/weapons/$id'
     | '/accessories/'
     | '/armor/'
@@ -276,6 +342,8 @@ export interface FileRouteTypes {
     | '/crafting/'
     | '/gems/'
     | '/grips/'
+    | '/keys/'
+    | '/spells/'
     | '/weapons/'
   fileRoutesById: FileRoutesById
 }
@@ -286,6 +354,8 @@ export interface RootRouteChildren {
   ConsumablesRouteRoute: typeof ConsumablesRouteRouteWithChildren
   GemsRouteRoute: typeof GemsRouteRouteWithChildren
   GripsRouteRoute: typeof GripsRouteRouteWithChildren
+  KeysRouteRoute: typeof KeysRouteRouteWithChildren
+  SpellsRouteRoute: typeof SpellsRouteRouteWithChildren
   WeaponsRouteRoute: typeof WeaponsRouteRouteWithChildren
   MaterialGridRoute: typeof MaterialGridRoute
   MaterialsRoute: typeof MaterialsRoute
@@ -313,6 +383,20 @@ declare module '@tanstack/react-router' {
       path: '/weapons'
       fullPath: '/weapons'
       preLoaderRoute: typeof WeaponsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/spells': {
+      id: '/spells'
+      path: '/spells'
+      fullPath: '/spells'
+      preLoaderRoute: typeof SpellsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/keys': {
+      id: '/keys'
+      path: '/keys'
+      fullPath: '/keys'
+      preLoaderRoute: typeof KeysRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/grips': {
@@ -364,6 +448,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WeaponsIndexRouteImport
       parentRoute: typeof WeaponsRouteRoute
     }
+    '/spells/': {
+      id: '/spells/'
+      path: '/'
+      fullPath: '/spells/'
+      preLoaderRoute: typeof SpellsIndexRouteImport
+      parentRoute: typeof SpellsRouteRoute
+    }
+    '/keys/': {
+      id: '/keys/'
+      path: '/'
+      fullPath: '/keys/'
+      preLoaderRoute: typeof KeysIndexRouteImport
+      parentRoute: typeof KeysRouteRoute
+    }
     '/grips/': {
       id: '/grips/'
       path: '/'
@@ -412,6 +510,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/weapons/$id'
       preLoaderRoute: typeof WeaponsIdRouteImport
       parentRoute: typeof WeaponsRouteRoute
+    }
+    '/spells/$id': {
+      id: '/spells/$id'
+      path: '/$id'
+      fullPath: '/spells/$id'
+      preLoaderRoute: typeof SpellsIdRouteImport
+      parentRoute: typeof SpellsRouteRoute
+    }
+    '/keys/$id': {
+      id: '/keys/$id'
+      path: '/$id'
+      fullPath: '/keys/$id'
+      preLoaderRoute: typeof KeysIdRouteImport
+      parentRoute: typeof KeysRouteRoute
     }
     '/grips/$id': {
       id: '/grips/$id'
@@ -519,6 +631,34 @@ const GripsRouteRouteWithChildren = GripsRouteRoute._addFileChildren(
   GripsRouteRouteChildren,
 )
 
+interface KeysRouteRouteChildren {
+  KeysIdRoute: typeof KeysIdRoute
+  KeysIndexRoute: typeof KeysIndexRoute
+}
+
+const KeysRouteRouteChildren: KeysRouteRouteChildren = {
+  KeysIdRoute: KeysIdRoute,
+  KeysIndexRoute: KeysIndexRoute,
+}
+
+const KeysRouteRouteWithChildren = KeysRouteRoute._addFileChildren(
+  KeysRouteRouteChildren,
+)
+
+interface SpellsRouteRouteChildren {
+  SpellsIdRoute: typeof SpellsIdRoute
+  SpellsIndexRoute: typeof SpellsIndexRoute
+}
+
+const SpellsRouteRouteChildren: SpellsRouteRouteChildren = {
+  SpellsIdRoute: SpellsIdRoute,
+  SpellsIndexRoute: SpellsIndexRoute,
+}
+
+const SpellsRouteRouteWithChildren = SpellsRouteRoute._addFileChildren(
+  SpellsRouteRouteChildren,
+)
+
 interface WeaponsRouteRouteChildren {
   WeaponsIdRoute: typeof WeaponsIdRoute
   WeaponsIndexRoute: typeof WeaponsIndexRoute
@@ -540,6 +680,8 @@ const rootRouteChildren: RootRouteChildren = {
   ConsumablesRouteRoute: ConsumablesRouteRouteWithChildren,
   GemsRouteRoute: GemsRouteRouteWithChildren,
   GripsRouteRoute: GripsRouteRouteWithChildren,
+  KeysRouteRoute: KeysRouteRouteWithChildren,
+  SpellsRouteRoute: SpellsRouteRouteWithChildren,
   WeaponsRouteRoute: WeaponsRouteRouteWithChildren,
   MaterialGridRoute: MaterialGridRoute,
   MaterialsRoute: MaterialsRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -60,6 +60,7 @@ const ITEM_LINKS = [
   { to: "/gems" as const, label: "Gems" },
   { to: "/consumables" as const, label: "Consumables" },
   { to: "/spells" as const, label: "Spells" },
+  { to: "/keys" as const, label: "Keys" },
 ]
 
 const NAV_TABS = [
@@ -71,6 +72,7 @@ const NAV_TABS = [
   { to: "/gems" as const, label: "Gems" },
   { to: "/consumables" as const, label: "Consumables" },
   { to: "/spells" as const, label: "Spells" },
+  { to: "/keys" as const, label: "Keys" },
   { to: "/crafting" as const, label: "Crafting" },
   { to: "/material-grid" as const, label: "Material Grid" },
 ]

--- a/src/routes/keys/$id.tsx
+++ b/src/routes/keys/$id.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi } from "@/lib/game-api"
+
+export const Route = createFileRoute("/keys/$id")({
+  component: KeyDetail,
+})
+
+function KeyDetail() {
+  const { id } = Route.useParams()
+  const { data: keys = [] } = useQuery({
+    queryKey: ["keys"],
+    queryFn: gameApi.keys,
+  })
+
+  const item = keys.find((k) => k.id === Number(id))
+  if (!item) return null
+
+  const locations = item.locations_used
+    .split(", ")
+    .filter((l) => l.trim().length > 0)
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/keys"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <ItemIcon type="Key" size="lg" className="rounded-lg" />
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {item.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">Key</p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-4">
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Found in:
+                </span>{" "}
+                {item.room ? `${item.room} (${item.area})` : item.area}
+              </p>
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Source:
+                </span>{" "}
+                {item.source}
+              </p>
+            </div>
+            {locations.length > 0 && (
+              <div>
+                <p className="text-muted-foreground mb-1 text-sm font-medium">
+                  Opens doors in:
+                </p>
+                <ul className="space-y-0.5 text-sm">
+                  {locations.map((loc, i) => (
+                    <li key={i} className="text-muted-foreground">
+                      {loc}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/keys/index.tsx
+++ b/src/routes/keys/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/keys/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Keys</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Keys open locked doors throughout Lea Monde — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/keys/route.tsx
+++ b/src/routes/keys/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { KeysPage } from "@/pages/keys/keys-page"
+
+export const Route = createFileRoute("/keys")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <KeysPage />
+    </div>
+  ),
+})


### PR DESCRIPTION
## Summary
- New keys page with DataTable showing name, area, and source
- Detail view lists all door locations each key opens
- Added to nav tabs, items dropdown, and homepage

## Test plan
- [ ] /keys page loads and shows all keys
- [ ] Click on a key shows detail with all locations used
- [ ] Nav tabs and homepage include Keys

Closes #22