### PR TITLE
feat: add sigils page with detail view

### DIFF
--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -145,6 +145,15 @@ export interface Key {
   locations_used: string
 }
 
+export interface Sigil {
+  id: number
+  name: string
+  area: string
+  room: string
+  source: string
+  door_unlocks: string
+}
+
 export interface CraftingRecipe {
   id: number
   category: string
@@ -186,6 +195,7 @@ export const gameApi = {
   spells: () => fetchApi<Spell[]>("/spells?limit=200"),
   spell: (id: number) => fetchApi<Spell>(`/spells/${id}`),
   keys: () => fetchApi<Key[]>("/keys?limit=200"),
+  sigils: () => fetchApi<Sigil[]>("/sigils?limit=200"),
   craftingRecipes: (params?: string) =>
     fetchApi<CraftingRecipe[]>(
       `/crafting-recipes${params ? `?${params}` : "?limit=200"}`

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -34,6 +34,10 @@ export function HomePage() {
     queryKey: ["keys"],
     queryFn: gameApi.keys,
   })
+  const { data: sigils = [] } = useQuery({
+    queryKey: ["sigils"],
+    queryFn: gameApi.sigils,
+  })
   const { data: materials = [] } = useQuery({
     queryKey: ["materials"],
     queryFn: gameApi.materials,
@@ -91,6 +95,12 @@ export function HomePage() {
       label: "Keys",
       icon: "Key",
       count: keys.length,
+    },
+    {
+      to: "/sigils" as const,
+      label: "Sigils",
+      icon: "Sigil",
+      count: sigils.length,
     },
   ]
 

--- a/src/pages/sigils/sigils-page.tsx
+++ b/src/pages/sigils/sigils-page.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable } from "@/components/data-table"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi, type Sigil } from "@/lib/game-api"
+
+const columns: ColumnDef<Sigil>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <ItemIcon type="Sigil" />
+        <span className="font-medium">{row.original.name}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "area",
+    header: "Area",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "source",
+    header: "Source",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-muted-foreground text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "door_unlocks",
+    header: "Unlocks",
+    enableSorting: false,
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return (
+        <span className="text-muted-foreground line-clamp-1 text-sm">{v}</span>
+      )
+    },
+  },
+]
+
+export function SigilsPage() {
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["sigils"],
+    queryFn: gameApi.sigils,
+  })
+
+  const enriched = useMemo(
+    () => data.map((s) => ({ ...s, _display: s.name })),
+    [data]
+  )
+
+  return (
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search sigils..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/sigils/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as MaterialsRouteImport } from './routes/materials'
 import { Route as MaterialGridRouteImport } from './routes/material-grid'
 import { Route as WeaponsRouteRouteImport } from './routes/weapons/route'
 import { Route as SpellsRouteRouteImport } from './routes/spells/route'
+import { Route as SigilsRouteRouteImport } from './routes/sigils/route'
 import { Route as KeysRouteRouteImport } from './routes/keys/route'
 import { Route as GripsRouteRouteImport } from './routes/grips/route'
 import { Route as GemsRouteRouteImport } from './routes/gems/route'
@@ -22,6 +23,7 @@ import { Route as AccessoriesRouteRouteImport } from './routes/accessories/route
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WeaponsIndexRouteImport } from './routes/weapons/index'
 import { Route as SpellsIndexRouteImport } from './routes/spells/index'
+import { Route as SigilsIndexRouteImport } from './routes/sigils/index'
 import { Route as KeysIndexRouteImport } from './routes/keys/index'
 import { Route as GripsIndexRouteImport } from './routes/grips/index'
 import { Route as GemsIndexRouteImport } from './routes/gems/index'
@@ -31,6 +33,7 @@ import { Route as ArmorIndexRouteImport } from './routes/armor/index'
 import { Route as AccessoriesIndexRouteImport } from './routes/accessories/index'
 import { Route as WeaponsIdRouteImport } from './routes/weapons/$id'
 import { Route as SpellsIdRouteImport } from './routes/spells/$id'
+import { Route as SigilsIdRouteImport } from './routes/sigils/$id'
 import { Route as KeysIdRouteImport } from './routes/keys/$id'
 import { Route as GripsIdRouteImport } from './routes/grips/$id'
 import { Route as GemsIdRouteImport } from './routes/gems/$id'
@@ -56,6 +59,11 @@ const WeaponsRouteRoute = WeaponsRouteRouteImport.update({
 const SpellsRouteRoute = SpellsRouteRouteImport.update({
   id: '/spells',
   path: '/spells',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SigilsRouteRoute = SigilsRouteRouteImport.update({
+  id: '/sigils',
+  path: '/sigils',
   getParentRoute: () => rootRouteImport,
 } as any)
 const KeysRouteRoute = KeysRouteRouteImport.update({
@@ -103,6 +111,11 @@ const SpellsIndexRoute = SpellsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => SpellsRouteRoute,
 } as any)
+const SigilsIndexRoute = SigilsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => SigilsRouteRoute,
+} as any)
 const KeysIndexRoute = KeysIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -148,6 +161,11 @@ const SpellsIdRoute = SpellsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => SpellsRouteRoute,
 } as any)
+const SigilsIdRoute = SigilsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => SigilsRouteRoute,
+} as any)
 const KeysIdRoute = KeysIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -187,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/gems': typeof GemsRouteRouteWithChildren
   '/grips': typeof GripsRouteRouteWithChildren
   '/keys': typeof KeysRouteRouteWithChildren
+  '/sigils': typeof SigilsRouteRouteWithChildren
   '/spells': typeof SpellsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
   '/material-grid': typeof MaterialGridRoute
@@ -197,6 +216,7 @@ export interface FileRoutesByFullPath {
   '/gems/$id': typeof GemsIdRoute
   '/grips/$id': typeof GripsIdRoute
   '/keys/$id': typeof KeysIdRoute
+  '/sigils/$id': typeof SigilsIdRoute
   '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
@@ -206,6 +226,7 @@ export interface FileRoutesByFullPath {
   '/gems/': typeof GemsIndexRoute
   '/grips/': typeof GripsIndexRoute
   '/keys/': typeof KeysIndexRoute
+  '/sigils/': typeof SigilsIndexRoute
   '/spells/': typeof SpellsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
 }
@@ -219,6 +240,7 @@ export interface FileRoutesByTo {
   '/gems/$id': typeof GemsIdRoute
   '/grips/$id': typeof GripsIdRoute
   '/keys/$id': typeof KeysIdRoute
+  '/sigils/$id': typeof SigilsIdRoute
   '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
   '/accessories': typeof AccessoriesIndexRoute
@@ -228,6 +250,7 @@ export interface FileRoutesByTo {
   '/gems': typeof GemsIndexRoute
   '/grips': typeof GripsIndexRoute
   '/keys': typeof KeysIndexRoute
+  '/sigils': typeof SigilsIndexRoute
   '/spells': typeof SpellsIndexRoute
   '/weapons': typeof WeaponsIndexRoute
 }
@@ -240,6 +263,7 @@ export interface FileRoutesById {
   '/gems': typeof GemsRouteRouteWithChildren
   '/grips': typeof GripsRouteRouteWithChildren
   '/keys': typeof KeysRouteRouteWithChildren
+  '/sigils': typeof SigilsRouteRouteWithChildren
   '/spells': typeof SpellsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
   '/material-grid': typeof MaterialGridRoute
@@ -250,6 +274,7 @@ export interface FileRoutesById {
   '/gems/$id': typeof GemsIdRoute
   '/grips/$id': typeof GripsIdRoute
   '/keys/$id': typeof KeysIdRoute
+  '/sigils/$id': typeof SigilsIdRoute
   '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
@@ -259,6 +284,7 @@ export interface FileRoutesById {
   '/gems/': typeof GemsIndexRoute
   '/grips/': typeof GripsIndexRoute
   '/keys/': typeof KeysIndexRoute
+  '/sigils/': typeof SigilsIndexRoute
   '/spells/': typeof SpellsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
 }
@@ -272,6 +298,7 @@ export interface FileRouteTypes {
     | '/gems'
     | '/grips'
     | '/keys'
+    | '/sigils'
     | '/spells'
     | '/weapons'
     | '/material-grid'
@@ -282,6 +309,7 @@ export interface FileRouteTypes {
     | '/gems/$id'
     | '/grips/$id'
     | '/keys/$id'
+    | '/sigils/$id'
     | '/spells/$id'
     | '/weapons/$id'
     | '/accessories/'
@@ -291,6 +319,7 @@ export interface FileRouteTypes {
     | '/gems/'
     | '/grips/'
     | '/keys/'
+    | '/sigils/'
     | '/spells/'
     | '/weapons/'
   fileRoutesByTo: FileRoutesByTo
@@ -304,6 +333,7 @@ export interface FileRouteTypes {
     | '/gems/$id'
     | '/grips/$id'
     | '/keys/$id'
+    | '/sigils/$id'
     | '/spells/$id'
     | '/weapons/$id'
     | '/accessories'
@@ -313,6 +343,7 @@ export interface FileRouteTypes {
     | '/gems'
     | '/grips'
     | '/keys'
+    | '/sigils'
     | '/spells'
     | '/weapons'
   id:
@@ -324,6 +355,7 @@ export interface FileRouteTypes {
     | '/gems'
     | '/grips'
     | '/keys'
+    | '/sigils'
     | '/spells'
     | '/weapons'
     | '/material-grid'
@@ -334,6 +366,7 @@ export interface FileRouteTypes {
     | '/gems/$id'
     | '/grips/$id'
     | '/keys/$id'
+    | '/sigils/$id'
     | '/spells/$id'
     | '/weapons/$id'
     | '/accessories/'
@@ -343,6 +376,7 @@ export interface FileRouteTypes {
     | '/gems/'
     | '/grips/'
     | '/keys/'
+    | '/sigils/'
     | '/spells/'
     | '/weapons/'
   fileRoutesById: FileRoutesById
@@ -355,6 +389,7 @@ export interface RootRouteChildren {
   GemsRouteRoute: typeof GemsRouteRouteWithChildren
   GripsRouteRoute: typeof GripsRouteRouteWithChildren
   KeysRouteRoute: typeof KeysRouteRouteWithChildren
+  SigilsRouteRoute: typeof SigilsRouteRouteWithChildren
   SpellsRouteRoute: typeof SpellsRouteRouteWithChildren
   WeaponsRouteRoute: typeof WeaponsRouteRouteWithChildren
   MaterialGridRoute: typeof MaterialGridRoute
@@ -390,6 +425,13 @@ declare module '@tanstack/react-router' {
       path: '/spells'
       fullPath: '/spells'
       preLoaderRoute: typeof SpellsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sigils': {
+      id: '/sigils'
+      path: '/sigils'
+      fullPath: '/sigils'
+      preLoaderRoute: typeof SigilsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/keys': {
@@ -455,6 +497,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SpellsIndexRouteImport
       parentRoute: typeof SpellsRouteRoute
     }
+    '/sigils/': {
+      id: '/sigils/'
+      path: '/'
+      fullPath: '/sigils/'
+      preLoaderRoute: typeof SigilsIndexRouteImport
+      parentRoute: typeof SigilsRouteRoute
+    }
     '/keys/': {
       id: '/keys/'
       path: '/'
@@ -517,6 +566,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/spells/$id'
       preLoaderRoute: typeof SpellsIdRouteImport
       parentRoute: typeof SpellsRouteRoute
+    }
+    '/sigils/$id': {
+      id: '/sigils/$id'
+      path: '/$id'
+      fullPath: '/sigils/$id'
+      preLoaderRoute: typeof SigilsIdRouteImport
+      parentRoute: typeof SigilsRouteRoute
     }
     '/keys/$id': {
       id: '/keys/$id'
@@ -645,6 +701,20 @@ const KeysRouteRouteWithChildren = KeysRouteRoute._addFileChildren(
   KeysRouteRouteChildren,
 )
 
+interface SigilsRouteRouteChildren {
+  SigilsIdRoute: typeof SigilsIdRoute
+  SigilsIndexRoute: typeof SigilsIndexRoute
+}
+
+const SigilsRouteRouteChildren: SigilsRouteRouteChildren = {
+  SigilsIdRoute: SigilsIdRoute,
+  SigilsIndexRoute: SigilsIndexRoute,
+}
+
+const SigilsRouteRouteWithChildren = SigilsRouteRoute._addFileChildren(
+  SigilsRouteRouteChildren,
+)
+
 interface SpellsRouteRouteChildren {
   SpellsIdRoute: typeof SpellsIdRoute
   SpellsIndexRoute: typeof SpellsIndexRoute
@@ -681,6 +751,7 @@ const rootRouteChildren: RootRouteChildren = {
   GemsRouteRoute: GemsRouteRouteWithChildren,
   GripsRouteRoute: GripsRouteRouteWithChildren,
   KeysRouteRoute: KeysRouteRouteWithChildren,
+  SigilsRouteRoute: SigilsRouteRouteWithChildren,
   SpellsRouteRoute: SpellsRouteRouteWithChildren,
   WeaponsRouteRoute: WeaponsRouteRouteWithChildren,
   MaterialGridRoute: MaterialGridRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -61,6 +61,7 @@ const ITEM_LINKS = [
   { to: "/consumables" as const, label: "Consumables" },
   { to: "/spells" as const, label: "Spells" },
   { to: "/keys" as const, label: "Keys" },
+  { to: "/sigils" as const, label: "Sigils" },
 ]
 
 const NAV_TABS = [
@@ -73,6 +74,7 @@ const NAV_TABS = [
   { to: "/consumables" as const, label: "Consumables" },
   { to: "/spells" as const, label: "Spells" },
   { to: "/keys" as const, label: "Keys" },
+  { to: "/sigils" as const, label: "Sigils" },
   { to: "/crafting" as const, label: "Crafting" },
   { to: "/material-grid" as const, label: "Material Grid" },
 ]

--- a/src/routes/sigils/$id.tsx
+++ b/src/routes/sigils/$id.tsx
@@ -1,0 +1,69 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi } from "@/lib/game-api"
+
+export const Route = createFileRoute("/sigils/$id")({
+  component: SigilDetail,
+})
+
+function SigilDetail() {
+  const { id } = Route.useParams()
+  const { data: sigils = [] } = useQuery({
+    queryKey: ["sigils"],
+    queryFn: gameApi.sigils,
+  })
+
+  const item = sigils.find((s) => s.id === Number(id))
+  if (!item) return null
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/sigils"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <ItemIcon type="Sigil" size="lg" className="rounded-lg" />
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {item.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">Sigil</p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-4">
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Found in:
+                </span>{" "}
+                {item.room} ({item.area})
+              </p>
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Source:
+                </span>{" "}
+                {item.source}
+              </p>
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Unlocks:
+                </span>{" "}
+                {item.door_unlocks}
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/sigils/index.tsx
+++ b/src/routes/sigils/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/sigils/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Sigils</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Magical seals that dissolve arcane door barriers — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/sigils/route.tsx
+++ b/src/routes/sigils/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { SigilsPage } from "@/pages/sigils/sigils-page"
+
+export const Route = createFileRoute("/sigils")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <SigilsPage />
+    </div>
+  ),
+})


### PR DESCRIPTION
## Summary
- New sigils page with DataTable showing name, area, source, and unlock target
- Detail view shows full location and unlock info
- Added to nav tabs, items dropdown, and homepage

## Test plan
- [ ] /sigils page loads and shows all 24 sigils
- [ ] Click on a sigil shows detail with unlock location
- [ ] Nav tabs and homepage include Sigils

Closes #23