### PR TITLE
feat: add grimoires page with drop details

### DIFF
--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -154,6 +154,17 @@ export interface Sigil {
   door_unlocks: string
 }
 
+export interface Grimoire {
+  id: number
+  name: string
+  spell_name: string
+  area: string
+  room: string
+  source: string
+  drop_rate: string
+  repeatable: boolean
+}
+
 export interface CraftingRecipe {
   id: number
   category: string
@@ -196,6 +207,7 @@ export const gameApi = {
   spell: (id: number) => fetchApi<Spell>(`/spells/${id}`),
   keys: () => fetchApi<Key[]>("/keys?limit=200"),
   sigils: () => fetchApi<Sigil[]>("/sigils?limit=200"),
+  grimoires: () => fetchApi<Grimoire[]>("/grimoires?limit=500"),
   craftingRecipes: (params?: string) =>
     fetchApi<CraftingRecipe[]>(
       `/crafting-recipes${params ? `?${params}` : "?limit=200"}`

--- a/src/pages/grimoires/grimoires-page.tsx
+++ b/src/pages/grimoires/grimoires-page.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable } from "@/components/data-table"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi, type Grimoire } from "@/lib/game-api"
+
+const columns: ColumnDef<Grimoire>[] = [
+  {
+    accessorKey: "name",
+    header: "Grimoire",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <ItemIcon type="Grimoire" />
+        <span className="font-medium">{row.original.name}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "spell_name",
+    header: "Spell",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-primary text-sm font-medium">{v}</span>
+    },
+  },
+  {
+    accessorKey: "area",
+    header: "Area",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "source",
+    header: "Source",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-muted-foreground text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "drop_rate",
+    header: "Rate",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      if (!v) return <span className="text-muted-foreground">Once</span>
+      return <span className="text-sm">{v}</span>
+    },
+  },
+]
+
+export function GrimoiresPage() {
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["grimoires"],
+    queryFn: gameApi.grimoires,
+  })
+
+  const enriched = useMemo(
+    () => data.map((g) => ({ ...g, _display: g.name })),
+    [data]
+  )
+
+  return (
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search grimoires or spells..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/grimoires/$id",
+        params: { id: String(row.original.id) },
+      })}
+      pageSize={25}
+    />
+  )
+}

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -38,6 +38,10 @@ export function HomePage() {
     queryKey: ["sigils"],
     queryFn: gameApi.sigils,
   })
+  const { data: grimoires = [] } = useQuery({
+    queryKey: ["grimoires"],
+    queryFn: gameApi.grimoires,
+  })
   const { data: materials = [] } = useQuery({
     queryKey: ["materials"],
     queryFn: gameApi.materials,
@@ -101,6 +105,12 @@ export function HomePage() {
       label: "Sigils",
       icon: "Sigil",
       count: sigils.length,
+    },
+    {
+      to: "/grimoires" as const,
+      label: "Grimoires",
+      icon: "Grimoire",
+      count: grimoires.length,
     },
   ]
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as SpellsRouteRouteImport } from './routes/spells/route'
 import { Route as SigilsRouteRouteImport } from './routes/sigils/route'
 import { Route as KeysRouteRouteImport } from './routes/keys/route'
 import { Route as GripsRouteRouteImport } from './routes/grips/route'
+import { Route as GrimoiresRouteRouteImport } from './routes/grimoires/route'
 import { Route as GemsRouteRouteImport } from './routes/gems/route'
 import { Route as ConsumablesRouteRouteImport } from './routes/consumables/route'
 import { Route as ArmorRouteRouteImport } from './routes/armor/route'
@@ -26,6 +27,7 @@ import { Route as SpellsIndexRouteImport } from './routes/spells/index'
 import { Route as SigilsIndexRouteImport } from './routes/sigils/index'
 import { Route as KeysIndexRouteImport } from './routes/keys/index'
 import { Route as GripsIndexRouteImport } from './routes/grips/index'
+import { Route as GrimoiresIndexRouteImport } from './routes/grimoires/index'
 import { Route as GemsIndexRouteImport } from './routes/gems/index'
 import { Route as CraftingIndexRouteImport } from './routes/crafting/index'
 import { Route as ConsumablesIndexRouteImport } from './routes/consumables/index'
@@ -36,6 +38,7 @@ import { Route as SpellsIdRouteImport } from './routes/spells/$id'
 import { Route as SigilsIdRouteImport } from './routes/sigils/$id'
 import { Route as KeysIdRouteImport } from './routes/keys/$id'
 import { Route as GripsIdRouteImport } from './routes/grips/$id'
+import { Route as GrimoiresIdRouteImport } from './routes/grimoires/$id'
 import { Route as GemsIdRouteImport } from './routes/gems/$id'
 import { Route as ConsumablesIdRouteImport } from './routes/consumables/$id'
 import { Route as ArmorIdRouteImport } from './routes/armor/$id'
@@ -74,6 +77,11 @@ const KeysRouteRoute = KeysRouteRouteImport.update({
 const GripsRouteRoute = GripsRouteRouteImport.update({
   id: '/grips',
   path: '/grips',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GrimoiresRouteRoute = GrimoiresRouteRouteImport.update({
+  id: '/grimoires',
+  path: '/grimoires',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GemsRouteRoute = GemsRouteRouteImport.update({
@@ -126,6 +134,11 @@ const GripsIndexRoute = GripsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => GripsRouteRoute,
 } as any)
+const GrimoiresIndexRoute = GrimoiresIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => GrimoiresRouteRoute,
+} as any)
 const GemsIndexRoute = GemsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -176,6 +189,11 @@ const GripsIdRoute = GripsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => GripsRouteRoute,
 } as any)
+const GrimoiresIdRoute = GrimoiresIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => GrimoiresRouteRoute,
+} as any)
 const GemsIdRoute = GemsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -203,6 +221,7 @@ export interface FileRoutesByFullPath {
   '/armor': typeof ArmorRouteRouteWithChildren
   '/consumables': typeof ConsumablesRouteRouteWithChildren
   '/gems': typeof GemsRouteRouteWithChildren
+  '/grimoires': typeof GrimoiresRouteRouteWithChildren
   '/grips': typeof GripsRouteRouteWithChildren
   '/keys': typeof KeysRouteRouteWithChildren
   '/sigils': typeof SigilsRouteRouteWithChildren
@@ -214,6 +233,7 @@ export interface FileRoutesByFullPath {
   '/armor/$id': typeof ArmorIdRoute
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
+  '/grimoires/$id': typeof GrimoiresIdRoute
   '/grips/$id': typeof GripsIdRoute
   '/keys/$id': typeof KeysIdRoute
   '/sigils/$id': typeof SigilsIdRoute
@@ -224,6 +244,7 @@ export interface FileRoutesByFullPath {
   '/consumables/': typeof ConsumablesIndexRoute
   '/crafting/': typeof CraftingIndexRoute
   '/gems/': typeof GemsIndexRoute
+  '/grimoires/': typeof GrimoiresIndexRoute
   '/grips/': typeof GripsIndexRoute
   '/keys/': typeof KeysIndexRoute
   '/sigils/': typeof SigilsIndexRoute
@@ -238,6 +259,7 @@ export interface FileRoutesByTo {
   '/armor/$id': typeof ArmorIdRoute
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
+  '/grimoires/$id': typeof GrimoiresIdRoute
   '/grips/$id': typeof GripsIdRoute
   '/keys/$id': typeof KeysIdRoute
   '/sigils/$id': typeof SigilsIdRoute
@@ -248,6 +270,7 @@ export interface FileRoutesByTo {
   '/consumables': typeof ConsumablesIndexRoute
   '/crafting': typeof CraftingIndexRoute
   '/gems': typeof GemsIndexRoute
+  '/grimoires': typeof GrimoiresIndexRoute
   '/grips': typeof GripsIndexRoute
   '/keys': typeof KeysIndexRoute
   '/sigils': typeof SigilsIndexRoute
@@ -261,6 +284,7 @@ export interface FileRoutesById {
   '/armor': typeof ArmorRouteRouteWithChildren
   '/consumables': typeof ConsumablesRouteRouteWithChildren
   '/gems': typeof GemsRouteRouteWithChildren
+  '/grimoires': typeof GrimoiresRouteRouteWithChildren
   '/grips': typeof GripsRouteRouteWithChildren
   '/keys': typeof KeysRouteRouteWithChildren
   '/sigils': typeof SigilsRouteRouteWithChildren
@@ -272,6 +296,7 @@ export interface FileRoutesById {
   '/armor/$id': typeof ArmorIdRoute
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
+  '/grimoires/$id': typeof GrimoiresIdRoute
   '/grips/$id': typeof GripsIdRoute
   '/keys/$id': typeof KeysIdRoute
   '/sigils/$id': typeof SigilsIdRoute
@@ -282,6 +307,7 @@ export interface FileRoutesById {
   '/consumables/': typeof ConsumablesIndexRoute
   '/crafting/': typeof CraftingIndexRoute
   '/gems/': typeof GemsIndexRoute
+  '/grimoires/': typeof GrimoiresIndexRoute
   '/grips/': typeof GripsIndexRoute
   '/keys/': typeof KeysIndexRoute
   '/sigils/': typeof SigilsIndexRoute
@@ -296,6 +322,7 @@ export interface FileRouteTypes {
     | '/armor'
     | '/consumables'
     | '/gems'
+    | '/grimoires'
     | '/grips'
     | '/keys'
     | '/sigils'
@@ -307,6 +334,7 @@ export interface FileRouteTypes {
     | '/armor/$id'
     | '/consumables/$id'
     | '/gems/$id'
+    | '/grimoires/$id'
     | '/grips/$id'
     | '/keys/$id'
     | '/sigils/$id'
@@ -317,6 +345,7 @@ export interface FileRouteTypes {
     | '/consumables/'
     | '/crafting/'
     | '/gems/'
+    | '/grimoires/'
     | '/grips/'
     | '/keys/'
     | '/sigils/'
@@ -331,6 +360,7 @@ export interface FileRouteTypes {
     | '/armor/$id'
     | '/consumables/$id'
     | '/gems/$id'
+    | '/grimoires/$id'
     | '/grips/$id'
     | '/keys/$id'
     | '/sigils/$id'
@@ -341,6 +371,7 @@ export interface FileRouteTypes {
     | '/consumables'
     | '/crafting'
     | '/gems'
+    | '/grimoires'
     | '/grips'
     | '/keys'
     | '/sigils'
@@ -353,6 +384,7 @@ export interface FileRouteTypes {
     | '/armor'
     | '/consumables'
     | '/gems'
+    | '/grimoires'
     | '/grips'
     | '/keys'
     | '/sigils'
@@ -364,6 +396,7 @@ export interface FileRouteTypes {
     | '/armor/$id'
     | '/consumables/$id'
     | '/gems/$id'
+    | '/grimoires/$id'
     | '/grips/$id'
     | '/keys/$id'
     | '/sigils/$id'
@@ -374,6 +407,7 @@ export interface FileRouteTypes {
     | '/consumables/'
     | '/crafting/'
     | '/gems/'
+    | '/grimoires/'
     | '/grips/'
     | '/keys/'
     | '/sigils/'
@@ -387,6 +421,7 @@ export interface RootRouteChildren {
   ArmorRouteRoute: typeof ArmorRouteRouteWithChildren
   ConsumablesRouteRoute: typeof ConsumablesRouteRouteWithChildren
   GemsRouteRoute: typeof GemsRouteRouteWithChildren
+  GrimoiresRouteRoute: typeof GrimoiresRouteRouteWithChildren
   GripsRouteRoute: typeof GripsRouteRouteWithChildren
   KeysRouteRoute: typeof KeysRouteRouteWithChildren
   SigilsRouteRoute: typeof SigilsRouteRouteWithChildren
@@ -446,6 +481,13 @@ declare module '@tanstack/react-router' {
       path: '/grips'
       fullPath: '/grips'
       preLoaderRoute: typeof GripsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/grimoires': {
+      id: '/grimoires'
+      path: '/grimoires'
+      fullPath: '/grimoires'
+      preLoaderRoute: typeof GrimoiresRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/gems': {
@@ -518,6 +560,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GripsIndexRouteImport
       parentRoute: typeof GripsRouteRoute
     }
+    '/grimoires/': {
+      id: '/grimoires/'
+      path: '/'
+      fullPath: '/grimoires/'
+      preLoaderRoute: typeof GrimoiresIndexRouteImport
+      parentRoute: typeof GrimoiresRouteRoute
+    }
     '/gems/': {
       id: '/gems/'
       path: '/'
@@ -587,6 +636,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/grips/$id'
       preLoaderRoute: typeof GripsIdRouteImport
       parentRoute: typeof GripsRouteRoute
+    }
+    '/grimoires/$id': {
+      id: '/grimoires/$id'
+      path: '/$id'
+      fullPath: '/grimoires/$id'
+      preLoaderRoute: typeof GrimoiresIdRouteImport
+      parentRoute: typeof GrimoiresRouteRoute
     }
     '/gems/$id': {
       id: '/gems/$id'
@@ -673,6 +729,20 @@ const GemsRouteRouteWithChildren = GemsRouteRoute._addFileChildren(
   GemsRouteRouteChildren,
 )
 
+interface GrimoiresRouteRouteChildren {
+  GrimoiresIdRoute: typeof GrimoiresIdRoute
+  GrimoiresIndexRoute: typeof GrimoiresIndexRoute
+}
+
+const GrimoiresRouteRouteChildren: GrimoiresRouteRouteChildren = {
+  GrimoiresIdRoute: GrimoiresIdRoute,
+  GrimoiresIndexRoute: GrimoiresIndexRoute,
+}
+
+const GrimoiresRouteRouteWithChildren = GrimoiresRouteRoute._addFileChildren(
+  GrimoiresRouteRouteChildren,
+)
+
 interface GripsRouteRouteChildren {
   GripsIdRoute: typeof GripsIdRoute
   GripsIndexRoute: typeof GripsIndexRoute
@@ -749,6 +819,7 @@ const rootRouteChildren: RootRouteChildren = {
   ArmorRouteRoute: ArmorRouteRouteWithChildren,
   ConsumablesRouteRoute: ConsumablesRouteRouteWithChildren,
   GemsRouteRoute: GemsRouteRouteWithChildren,
+  GrimoiresRouteRoute: GrimoiresRouteRouteWithChildren,
   GripsRouteRoute: GripsRouteRouteWithChildren,
   KeysRouteRoute: KeysRouteRouteWithChildren,
   SigilsRouteRoute: SigilsRouteRouteWithChildren,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -62,6 +62,7 @@ const ITEM_LINKS = [
   { to: "/spells" as const, label: "Spells" },
   { to: "/keys" as const, label: "Keys" },
   { to: "/sigils" as const, label: "Sigils" },
+  { to: "/grimoires" as const, label: "Grimoires" },
 ]
 
 const NAV_TABS = [
@@ -75,6 +76,7 @@ const NAV_TABS = [
   { to: "/spells" as const, label: "Spells" },
   { to: "/keys" as const, label: "Keys" },
   { to: "/sigils" as const, label: "Sigils" },
+  { to: "/grimoires" as const, label: "Grimoires" },
   { to: "/crafting" as const, label: "Crafting" },
   { to: "/material-grid" as const, label: "Material Grid" },
 ]

--- a/src/routes/grimoires/$id.tsx
+++ b/src/routes/grimoires/$id.tsx
@@ -1,0 +1,73 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi } from "@/lib/game-api"
+
+export const Route = createFileRoute("/grimoires/$id")({
+  component: GrimoireDetail,
+})
+
+function GrimoireDetail() {
+  const { id } = Route.useParams()
+  const { data: grimoires = [] } = useQuery({
+    queryKey: ["grimoires"],
+    queryFn: gameApi.grimoires,
+  })
+
+  const item = grimoires.find((g) => g.id === Number(id))
+  if (!item) return null
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/grimoires"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <ItemIcon type="Grimoire" size="lg" className="rounded-lg" />
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                Grimoire {item.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">Grimoire</p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-4">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="secondary">{item.spell_name}</Badge>
+              {item.drop_rate ? (
+                <Badge variant="outline">{item.drop_rate}</Badge>
+              ) : (
+                <Badge variant="outline">Once</Badge>
+              )}
+              {item.repeatable && <Badge variant="outline">Repeatable</Badge>}
+            </div>
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Location:
+                </span>{" "}
+                {item.room} ({item.area})
+              </p>
+              <p>
+                <span className="text-muted-foreground font-medium">
+                  Source:
+                </span>{" "}
+                {item.source}
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/grimoires/index.tsx
+++ b/src/routes/grimoires/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/grimoires/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Grimoires</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Spell books that teach magic — click for drop details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/grimoires/route.tsx
+++ b/src/routes/grimoires/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { GrimoiresPage } from "@/pages/grimoires/grimoires-page"
+
+export const Route = createFileRoute("/grimoires")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <GrimoiresPage />
+    </div>
+  ),
+})


### PR DESCRIPTION
## Summary
- New grimoires page with DataTable showing grimoire name, spell, area, source, and drop rate
- Detail view shows full location, source enemy/chest, and repeatability badges
- Added to nav tabs, items dropdown, and homepage

## Test plan
- [ ] /grimoires page loads and shows all grimoire drop sources
- [ ] Search works for grimoire and spell names
- [ ] Click on entry shows detail card
- [ ] Nav tabs and homepage include Grimoires

Closes #24