### PR TITLE
feat: add workshops page with material info

### DIFF
--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -165,6 +165,14 @@ export interface Grimoire {
   repeatable: boolean
 }
 
+export interface Workshop {
+  id: number
+  name: string
+  area: string
+  available_materials: string
+  description: string
+}
+
 export interface CraftingRecipe {
   id: number
   category: string
@@ -208,6 +216,7 @@ export const gameApi = {
   keys: () => fetchApi<Key[]>("/keys?limit=200"),
   sigils: () => fetchApi<Sigil[]>("/sigils?limit=200"),
   grimoires: () => fetchApi<Grimoire[]>("/grimoires?limit=500"),
+  workshops: () => fetchApi<Workshop[]>("/workshops?limit=200"),
   craftingRecipes: (params?: string) =>
     fetchApi<CraftingRecipe[]>(
       `/crafting-recipes${params ? `?${params}` : "?limit=200"}`

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -42,6 +42,10 @@ export function HomePage() {
     queryKey: ["grimoires"],
     queryFn: gameApi.grimoires,
   })
+  const { data: workshops = [] } = useQuery({
+    queryKey: ["workshops"],
+    queryFn: gameApi.workshops,
+  })
   const { data: materials = [] } = useQuery({
     queryKey: ["materials"],
     queryFn: gameApi.materials,
@@ -111,6 +115,12 @@ export function HomePage() {
       label: "Grimoires",
       icon: "Grimoire",
       count: grimoires.length,
+    },
+    {
+      to: "/workshops" as const,
+      label: "Workshops",
+      icon: "Workshop",
+      count: workshops.length,
     },
   ]
 

--- a/src/pages/workshops/workshops-page.tsx
+++ b/src/pages/workshops/workshops-page.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { ArrowRight } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi } from "@/lib/game-api"
+
+export function WorkshopsPage() {
+  const { data: workshops = [], isLoading } = useQuery({
+    queryKey: ["workshops"],
+    queryFn: gameApi.workshops,
+  })
+
+  if (isLoading) {
+    return <p className="text-muted-foreground py-8 text-center">Loading...</p>
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {workshops.map((ws) => (
+        <Link key={ws.id} to="/workshops/$id" params={{ id: String(ws.id) }}>
+          <Card className="hover:border-primary/40 h-full transition-colors">
+            <CardContent className="flex flex-col gap-3 pt-6">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-3">
+                  <ItemIcon type="Workshop" />
+                  <h3 className="font-sans text-lg font-medium">{ws.name}</h3>
+                </div>
+                <ArrowRight className="text-muted-foreground mt-1 size-4 shrink-0" />
+              </div>
+              <p className="text-muted-foreground text-sm">{ws.area}</p>
+              <div className="flex flex-wrap gap-1.5">
+                {ws.available_materials.split(", ").map((mat) => (
+                  <Badge key={mat} variant="secondary" className="text-xs">
+                    {mat}
+                  </Badge>
+                ))}
+              </div>
+              <p className="text-muted-foreground text-sm">{ws.description}</p>
+            </CardContent>
+          </Card>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as MaterialsRouteImport } from './routes/materials'
 import { Route as MaterialGridRouteImport } from './routes/material-grid'
+import { Route as WorkshopsRouteRouteImport } from './routes/workshops/route'
 import { Route as WeaponsRouteRouteImport } from './routes/weapons/route'
 import { Route as SpellsRouteRouteImport } from './routes/spells/route'
 import { Route as SigilsRouteRouteImport } from './routes/sigils/route'
@@ -22,6 +23,7 @@ import { Route as ConsumablesRouteRouteImport } from './routes/consumables/route
 import { Route as ArmorRouteRouteImport } from './routes/armor/route'
 import { Route as AccessoriesRouteRouteImport } from './routes/accessories/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as WorkshopsIndexRouteImport } from './routes/workshops/index'
 import { Route as WeaponsIndexRouteImport } from './routes/weapons/index'
 import { Route as SpellsIndexRouteImport } from './routes/spells/index'
 import { Route as SigilsIndexRouteImport } from './routes/sigils/index'
@@ -33,6 +35,7 @@ import { Route as CraftingIndexRouteImport } from './routes/crafting/index'
 import { Route as ConsumablesIndexRouteImport } from './routes/consumables/index'
 import { Route as ArmorIndexRouteImport } from './routes/armor/index'
 import { Route as AccessoriesIndexRouteImport } from './routes/accessories/index'
+import { Route as WorkshopsIdRouteImport } from './routes/workshops/$id'
 import { Route as WeaponsIdRouteImport } from './routes/weapons/$id'
 import { Route as SpellsIdRouteImport } from './routes/spells/$id'
 import { Route as SigilsIdRouteImport } from './routes/sigils/$id'
@@ -52,6 +55,11 @@ const MaterialsRoute = MaterialsRouteImport.update({
 const MaterialGridRoute = MaterialGridRouteImport.update({
   id: '/material-grid',
   path: '/material-grid',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const WorkshopsRouteRoute = WorkshopsRouteRouteImport.update({
+  id: '/workshops',
+  path: '/workshops',
   getParentRoute: () => rootRouteImport,
 } as any)
 const WeaponsRouteRoute = WeaponsRouteRouteImport.update({
@@ -109,6 +117,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const WorkshopsIndexRoute = WorkshopsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => WorkshopsRouteRoute,
+} as any)
 const WeaponsIndexRoute = WeaponsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -163,6 +176,11 @@ const AccessoriesIndexRoute = AccessoriesIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AccessoriesRouteRoute,
+} as any)
+const WorkshopsIdRoute = WorkshopsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => WorkshopsRouteRoute,
 } as any)
 const WeaponsIdRoute = WeaponsIdRouteImport.update({
   id: '/$id',
@@ -227,6 +245,7 @@ export interface FileRoutesByFullPath {
   '/sigils': typeof SigilsRouteRouteWithChildren
   '/spells': typeof SpellsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
+  '/workshops': typeof WorkshopsRouteRouteWithChildren
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
   '/accessories/$id': typeof AccessoriesIdRoute
@@ -239,6 +258,7 @@ export interface FileRoutesByFullPath {
   '/sigils/$id': typeof SigilsIdRoute
   '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
+  '/workshops/$id': typeof WorkshopsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
   '/armor/': typeof ArmorIndexRoute
   '/consumables/': typeof ConsumablesIndexRoute
@@ -250,6 +270,7 @@ export interface FileRoutesByFullPath {
   '/sigils/': typeof SigilsIndexRoute
   '/spells/': typeof SpellsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
+  '/workshops/': typeof WorkshopsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -265,6 +286,7 @@ export interface FileRoutesByTo {
   '/sigils/$id': typeof SigilsIdRoute
   '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
+  '/workshops/$id': typeof WorkshopsIdRoute
   '/accessories': typeof AccessoriesIndexRoute
   '/armor': typeof ArmorIndexRoute
   '/consumables': typeof ConsumablesIndexRoute
@@ -276,6 +298,7 @@ export interface FileRoutesByTo {
   '/sigils': typeof SigilsIndexRoute
   '/spells': typeof SpellsIndexRoute
   '/weapons': typeof WeaponsIndexRoute
+  '/workshops': typeof WorkshopsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -290,6 +313,7 @@ export interface FileRoutesById {
   '/sigils': typeof SigilsRouteRouteWithChildren
   '/spells': typeof SpellsRouteRouteWithChildren
   '/weapons': typeof WeaponsRouteRouteWithChildren
+  '/workshops': typeof WorkshopsRouteRouteWithChildren
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
   '/accessories/$id': typeof AccessoriesIdRoute
@@ -302,6 +326,7 @@ export interface FileRoutesById {
   '/sigils/$id': typeof SigilsIdRoute
   '/spells/$id': typeof SpellsIdRoute
   '/weapons/$id': typeof WeaponsIdRoute
+  '/workshops/$id': typeof WorkshopsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
   '/armor/': typeof ArmorIndexRoute
   '/consumables/': typeof ConsumablesIndexRoute
@@ -313,6 +338,7 @@ export interface FileRoutesById {
   '/sigils/': typeof SigilsIndexRoute
   '/spells/': typeof SpellsIndexRoute
   '/weapons/': typeof WeaponsIndexRoute
+  '/workshops/': typeof WorkshopsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -328,6 +354,7 @@ export interface FileRouteTypes {
     | '/sigils'
     | '/spells'
     | '/weapons'
+    | '/workshops'
     | '/material-grid'
     | '/materials'
     | '/accessories/$id'
@@ -340,6 +367,7 @@ export interface FileRouteTypes {
     | '/sigils/$id'
     | '/spells/$id'
     | '/weapons/$id'
+    | '/workshops/$id'
     | '/accessories/'
     | '/armor/'
     | '/consumables/'
@@ -351,6 +379,7 @@ export interface FileRouteTypes {
     | '/sigils/'
     | '/spells/'
     | '/weapons/'
+    | '/workshops/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -366,6 +395,7 @@ export interface FileRouteTypes {
     | '/sigils/$id'
     | '/spells/$id'
     | '/weapons/$id'
+    | '/workshops/$id'
     | '/accessories'
     | '/armor'
     | '/consumables'
@@ -377,6 +407,7 @@ export interface FileRouteTypes {
     | '/sigils'
     | '/spells'
     | '/weapons'
+    | '/workshops'
   id:
     | '__root__'
     | '/'
@@ -390,6 +421,7 @@ export interface FileRouteTypes {
     | '/sigils'
     | '/spells'
     | '/weapons'
+    | '/workshops'
     | '/material-grid'
     | '/materials'
     | '/accessories/$id'
@@ -402,6 +434,7 @@ export interface FileRouteTypes {
     | '/sigils/$id'
     | '/spells/$id'
     | '/weapons/$id'
+    | '/workshops/$id'
     | '/accessories/'
     | '/armor/'
     | '/consumables/'
@@ -413,6 +446,7 @@ export interface FileRouteTypes {
     | '/sigils/'
     | '/spells/'
     | '/weapons/'
+    | '/workshops/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -427,6 +461,7 @@ export interface RootRouteChildren {
   SigilsRouteRoute: typeof SigilsRouteRouteWithChildren
   SpellsRouteRoute: typeof SpellsRouteRouteWithChildren
   WeaponsRouteRoute: typeof WeaponsRouteRouteWithChildren
+  WorkshopsRouteRoute: typeof WorkshopsRouteRouteWithChildren
   MaterialGridRoute: typeof MaterialGridRoute
   MaterialsRoute: typeof MaterialsRoute
   CraftingIndexRoute: typeof CraftingIndexRoute
@@ -446,6 +481,13 @@ declare module '@tanstack/react-router' {
       path: '/material-grid'
       fullPath: '/material-grid'
       preLoaderRoute: typeof MaterialGridRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/workshops': {
+      id: '/workshops'
+      path: '/workshops'
+      fullPath: '/workshops'
+      preLoaderRoute: typeof WorkshopsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/weapons': {
@@ -525,6 +567,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/workshops/': {
+      id: '/workshops/'
+      path: '/'
+      fullPath: '/workshops/'
+      preLoaderRoute: typeof WorkshopsIndexRouteImport
+      parentRoute: typeof WorkshopsRouteRoute
+    }
     '/weapons/': {
       id: '/weapons/'
       path: '/'
@@ -601,6 +650,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/accessories/'
       preLoaderRoute: typeof AccessoriesIndexRouteImport
       parentRoute: typeof AccessoriesRouteRoute
+    }
+    '/workshops/$id': {
+      id: '/workshops/$id'
+      path: '/$id'
+      fullPath: '/workshops/$id'
+      preLoaderRoute: typeof WorkshopsIdRouteImport
+      parentRoute: typeof WorkshopsRouteRoute
     }
     '/weapons/$id': {
       id: '/weapons/$id'
@@ -813,6 +869,20 @@ const WeaponsRouteRouteWithChildren = WeaponsRouteRoute._addFileChildren(
   WeaponsRouteRouteChildren,
 )
 
+interface WorkshopsRouteRouteChildren {
+  WorkshopsIdRoute: typeof WorkshopsIdRoute
+  WorkshopsIndexRoute: typeof WorkshopsIndexRoute
+}
+
+const WorkshopsRouteRouteChildren: WorkshopsRouteRouteChildren = {
+  WorkshopsIdRoute: WorkshopsIdRoute,
+  WorkshopsIndexRoute: WorkshopsIndexRoute,
+}
+
+const WorkshopsRouteRouteWithChildren = WorkshopsRouteRoute._addFileChildren(
+  WorkshopsRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccessoriesRouteRoute: AccessoriesRouteRouteWithChildren,
@@ -825,6 +895,7 @@ const rootRouteChildren: RootRouteChildren = {
   SigilsRouteRoute: SigilsRouteRouteWithChildren,
   SpellsRouteRoute: SpellsRouteRouteWithChildren,
   WeaponsRouteRoute: WeaponsRouteRouteWithChildren,
+  WorkshopsRouteRoute: WorkshopsRouteRouteWithChildren,
   MaterialGridRoute: MaterialGridRoute,
   MaterialsRoute: MaterialsRoute,
   CraftingIndexRoute: CraftingIndexRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -63,6 +63,7 @@ const ITEM_LINKS = [
   { to: "/keys" as const, label: "Keys" },
   { to: "/sigils" as const, label: "Sigils" },
   { to: "/grimoires" as const, label: "Grimoires" },
+  { to: "/workshops" as const, label: "Workshops" },
 ]
 
 const NAV_TABS = [
@@ -77,6 +78,7 @@ const NAV_TABS = [
   { to: "/keys" as const, label: "Keys" },
   { to: "/sigils" as const, label: "Sigils" },
   { to: "/grimoires" as const, label: "Grimoires" },
+  { to: "/workshops" as const, label: "Workshops" },
   { to: "/crafting" as const, label: "Crafting" },
   { to: "/material-grid" as const, label: "Material Grid" },
 ]

--- a/src/routes/workshops/$id.tsx
+++ b/src/routes/workshops/$id.tsx
@@ -1,0 +1,77 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi } from "@/lib/game-api"
+
+export const Route = createFileRoute("/workshops/$id")({
+  component: WorkshopDetail,
+})
+
+function WorkshopDetail() {
+  const { id } = Route.useParams()
+  const { data: workshops = [] } = useQuery({
+    queryKey: ["workshops"],
+    queryFn: gameApi.workshops,
+  })
+
+  const item = workshops.find((w) => w.id === Number(id))
+  if (!item) return null
+
+  const materials = item.available_materials
+    .split(", ")
+    .filter((m) => m.trim().length > 0)
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/workshops"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <ItemIcon type="Workshop" size="lg" className="rounded-lg" />
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {item.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">Workshop</p>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-4">
+            <p className="text-sm">
+              <span className="text-muted-foreground font-medium">
+                Location:
+              </span>{" "}
+              {item.area}
+            </p>
+            <div>
+              <p className="text-muted-foreground mb-1.5 text-sm font-medium">
+                Available Materials:
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {materials.map((mat) => (
+                  <Badge key={mat} variant="secondary">
+                    {mat}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+            {item.description && (
+              <p className="text-muted-foreground text-sm">
+                {item.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/workshops/index.tsx
+++ b/src/routes/workshops/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/workshops/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Workshops</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Crafting locations throughout Lea Monde — click for details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/workshops/route.tsx
+++ b/src/routes/workshops/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { WorkshopsPage } from "@/pages/workshops/workshops-page"
+
+export const Route = createFileRoute("/workshops")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <Outlet />
+      <WorkshopsPage />
+    </div>
+  ),
+})


### PR DESCRIPTION
## Summary
- New workshops page with card grid layout showing all 6 crafting locations
- Each card shows workshop name, location, available materials as badges, and description
- Detail view with expanded material badges
- Added to nav tabs, items dropdown, and homepage

## Test plan
- [ ] /workshops page loads with 6 workshop cards
- [ ] Click on workshop shows detail view
- [ ] Material badges display correctly
- [ ] Nav tabs and homepage include Workshops

Closes #17