### PR TITLE
feat: display enriched consumable data

### DIFF
--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -123,6 +123,13 @@ export interface Consumable {
   description_fr?: string
   description?: string
   effects?: unknown
+  hp_restore?: string
+  mp_restore?: string
+  risk_reduce?: string
+  status_cure?: string
+  permanent_stat?: string
+  drop_rate?: string
+  drop_location?: string
 }
 
 export interface Spell {

--- a/src/pages/consumables/consumables-page.tsx
+++ b/src/pages/consumables/consumables-page.tsx
@@ -26,6 +26,15 @@ const columns: ColumnDef<Consumable>[] = [
     },
     enableSorting: false,
   },
+  {
+    accessorKey: "drop_rate",
+    header: "Drop Rate",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      if (!v) return <span className="text-muted-foreground">-</span>
+      return <span className="text-muted-foreground text-sm">{v}</span>
+    },
+  },
 ]
 
 export function ConsumablesPage() {

--- a/src/routes/consumables/$id.tsx
+++ b/src/routes/consumables/$id.tsx
@@ -19,6 +19,16 @@ function ConsumableDetail() {
   const item = consumables.find((c) => c.id === Number(id))
   if (!item) return null
 
+  const details = [
+    { label: "HP Restore", value: item.hp_restore },
+    { label: "MP Restore", value: item.mp_restore },
+    { label: "RISK Reduce", value: item.risk_reduce },
+    { label: "Status Cure", value: item.status_cure },
+    { label: "Permanent Stat", value: item.permanent_stat },
+    { label: "Drop Rate", value: item.drop_rate },
+    { label: "Drop Location", value: item.drop_location },
+  ].filter((d) => d.value)
+
   return (
     <Card className="border-primary/30 mx-auto max-w-3xl">
       <CardContent className="pt-6">
@@ -40,13 +50,25 @@ function ConsumableDetail() {
               <p className="text-muted-foreground mt-0.5 text-sm">Consumable</p>
             </div>
           </div>
-          <div className="flex flex-1 flex-col items-center justify-center gap-3">
+          <div className="flex flex-1 flex-col gap-3">
             {item.description ? (
-              <p className="text-center text-sm">{item.description}</p>
+              <p className="text-sm">{item.description}</p>
             ) : (
               <p className="text-muted-foreground text-sm">
                 No description available
               </p>
+            )}
+            {details.length > 0 && (
+              <div className="space-y-1.5">
+                {details.map((d) => (
+                  <p key={d.label} className="text-sm">
+                    <span className="text-muted-foreground font-medium">
+                      {d.label}:
+                    </span>{" "}
+                    {d.value}
+                  </p>
+                ))}
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add new consumable fields to TypeScript interface (hp_restore, mp_restore, risk_reduce, status_cure, permanent_stat, drop_rate, drop_location)
- Add drop rate column to consumables DataTable
- Detail view shows all enriched fields when available (HP/MP restore, RISK reduce, status cures, permanent stat bonuses, drop rate, drop location)

## Test plan
- [ ] /consumables table shows drop rate column
- [ ] Click on Cure Root shows HP Restore: 50 and other details
- [ ] Click on Panacea shows Status Cure: Paralysis, Poison, Numbness
- [ ] Click on Elixir of Kings shows Permanent Stat: STR +1-4

Closes #25