### PR TITLE
Shared material badges, sticky table headers

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -131,7 +131,7 @@ export function DataTable<T>({
           </Select>
         ))}
       </div>
-      <div className="overflow-x-auto rounded-md border">
+      <div className="max-h-[70vh] overflow-auto rounded-md border">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((hg) => (

--- a/src/components/stat-display.tsx
+++ b/src/components/stat-display.tsx
@@ -7,6 +7,29 @@ const DMG_TYPE_COLORS: Record<string, string> = {
   Piercing: "bg-sky-600/60 text-sky-100 border-sky-500/50",
 }
 
+const MAT_BADGE_COLORS: Record<string, string> = {
+  Wood: "bg-amber-900/60 text-amber-200 border-amber-700/50",
+  Leather: "bg-amber-700/60 text-amber-100 border-amber-600/50",
+  Bronze: "bg-orange-600/60 text-orange-100 border-orange-500/50",
+  Iron: "bg-slate-500/60 text-slate-100 border-slate-400/50",
+  Hagane: "bg-blue-600/60 text-blue-100 border-blue-500/50",
+  Silver: "bg-gray-300/70 text-gray-900 border-gray-400/50",
+  Damascus: "bg-purple-600/60 text-purple-100 border-purple-500/50",
+}
+
+export function MaterialBadge({ mat }: { mat: string }) {
+  return (
+    <span
+      className={cn(
+        "rounded border px-1.5 py-0.5 text-xs font-medium",
+        MAT_BADGE_COLORS[mat] ?? "bg-muted"
+      )}
+    >
+      {mat}
+    </span>
+  )
+}
+
 export function DamageTypeBadge({ type }: { type: string }) {
   return (
     <span

--- a/src/pages/crafting/crafting-page.tsx
+++ b/src/pages/crafting/crafting-page.tsx
@@ -33,7 +33,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { StatDisplay } from "@/components/stat-display"
+import { MaterialBadge, StatDisplay } from "@/components/stat-display"
 import {
   gameApi,
   type CraftingRecipe,
@@ -1074,16 +1074,6 @@ function ReverseTable({
   )
 }
 
-const MAT_BADGE_COLORS: Record<string, string> = {
-  Wood: "bg-amber-900/60 text-amber-200 border-amber-700/50",
-  Leather: "bg-amber-700/60 text-amber-100 border-amber-600/50",
-  Bronze: "bg-orange-600/60 text-orange-100 border-orange-500/50",
-  Iron: "bg-slate-500/60 text-slate-100 border-slate-400/50",
-  Hagane: "bg-blue-600/60 text-blue-100 border-blue-500/50",
-  Silver: "bg-gray-300/70 text-gray-900 border-gray-400/50",
-  Damascus: "bg-purple-600/60 text-purple-100 border-purple-500/50",
-}
-
 function SlotCell({
   name,
   type,
@@ -1131,17 +1121,4 @@ function SortIcon({ sorted }: { sorted: false | "asc" | "desc" }) {
   if (sorted === "asc") return <ArrowUp className="size-3.5" />
   if (sorted === "desc") return <ArrowDown className="size-3.5" />
   return <ArrowUpDown className="text-muted-foreground/50 size-3.5" />
-}
-
-function MaterialBadge({ mat }: { mat: string }) {
-  return (
-    <span
-      className={cn(
-        "rounded border px-1.5 py-0.5 text-xs font-medium",
-        MAT_BADGE_COLORS[mat] ?? "bg-muted"
-      )}
-    >
-      {mat}
-    </span>
-  )
 }

--- a/src/pages/materials/materials-page.tsx
+++ b/src/pages/materials/materials-page.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { ItemIcon } from "@/components/item-icon"
+import { MaterialBadge } from "@/components/stat-display"
 import { gameApi, type Material } from "@/lib/game-api"
 import { cn } from "@/lib/utils"
 
@@ -65,7 +66,7 @@ function MaterialCard({ material: m }: { material: Material }) {
     <div className="border-border/50 bg-card space-y-2 rounded-lg border p-3">
       <div className="flex items-center gap-2">
         <ItemIcon type="Material" size="sm" />
-        <h3 className="text-sm font-medium">{m.name}</h3>
+        <MaterialBadge mat={m.name} />
       </div>
 
       {categories && (

--- a/src/pages/workshops/workshops-page.tsx
+++ b/src/pages/workshops/workshops-page.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { ArrowRight } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { ItemIcon } from "@/components/item-icon"
+import { MaterialBadge } from "@/components/stat-display"
 import { gameApi } from "@/lib/game-api"
 
 export function WorkshopsPage() {
@@ -32,9 +32,7 @@ export function WorkshopsPage() {
               <p className="text-muted-foreground text-sm">{ws.area}</p>
               <div className="flex flex-wrap gap-1.5">
                 {ws.available_materials.split(", ").map((mat) => (
-                  <Badge key={mat} variant="secondary" className="text-xs">
-                    {mat}
-                  </Badge>
+                  <MaterialBadge key={mat} mat={mat} />
                 ))}
               </div>
               <p className="text-muted-foreground text-sm">{ws.description}</p>

--- a/src/routes/workshops/$id.tsx
+++ b/src/routes/workshops/$id.tsx
@@ -2,8 +2,8 @@ import { createFileRoute, Link } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { ItemIcon } from "@/components/item-icon"
+import { MaterialBadge } from "@/components/stat-display"
 import { gameApi } from "@/lib/game-api"
 
 export const Route = createFileRoute("/workshops/$id")({
@@ -58,9 +58,7 @@ function WorkshopDetail() {
               </p>
               <div className="flex flex-wrap gap-1.5">
                 {materials.map((mat) => (
-                  <Badge key={mat} variant="secondary">
-                    {mat}
-                  </Badge>
+                  <MaterialBadge key={mat} mat={mat} />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Extract MaterialBadge into shared component in stat-display.tsx
- Use colored material badges on workshops page, workshop detail, and material cards
- Remove duplicate badge code from crafting page
- Add sticky table headers with scrollable container (max-h 70vh)

## Test plan
- [ ] Verify colored material badges on workshops page and detail
- [ ] Verify colored material badges on material cards
- [ ] Verify crafting page material badges still work
- [ ] Verify table headers stick when scrolling