### PR TITLE
Fix scroll to top and mobile detail layout

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -42,6 +42,7 @@ const router = createRouter({
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  scrollRestoration: true,
   defaultErrorComponent: RootErrorComponent,
   defaultNotFoundComponent: NotFound,
 })

--- a/src/routes/accessories/$id.tsx
+++ b/src/routes/accessories/$id.tsx
@@ -31,7 +31,7 @@ function AccessoryDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type={"Accessory"} size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/armor/$id.tsx
+++ b/src/routes/armor/$id.tsx
@@ -59,7 +59,7 @@ function ArmorDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type={item.armor_type} size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/consumables/$id.tsx
+++ b/src/routes/consumables/$id.tsx
@@ -40,7 +40,7 @@ function ConsumableDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Consumable" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/gems/$id.tsx
+++ b/src/routes/gems/$id.tsx
@@ -54,7 +54,7 @@ function GemDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Gem" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/grimoires/$id.tsx
+++ b/src/routes/grimoires/$id.tsx
@@ -31,7 +31,7 @@ function GrimoireDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Grimoire" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/grips/$id.tsx
+++ b/src/routes/grips/$id.tsx
@@ -31,7 +31,7 @@ function GripDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Grip" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/keys/$id.tsx
+++ b/src/routes/keys/$id.tsx
@@ -34,7 +34,7 @@ function KeyDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Key" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/sigils/$id.tsx
+++ b/src/routes/sigils/$id.tsx
@@ -30,7 +30,7 @@ function SigilDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Sigil" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/spells/$id.tsx
+++ b/src/routes/spells/$id.tsx
@@ -31,7 +31,7 @@ function SpellDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Spell" size="lg" className="rounded-lg" />
             <div className="text-center">

--- a/src/routes/weapons/$id.tsx
+++ b/src/routes/weapons/$id.tsx
@@ -74,7 +74,7 @@ function WeaponDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           {/* Left: image, name, type, material */}
           <div className="flex flex-col items-center gap-3">
             <ItemIcon

--- a/src/routes/workshops/$id.tsx
+++ b/src/routes/workshops/$id.tsx
@@ -35,7 +35,7 @@ function WorkshopDetail() {
             <X className="size-5" />
           </Link>
         </div>
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 sm:flex-row">
           <div className="flex flex-col items-center gap-3">
             <ItemIcon type="Workshop" size="lg" className="rounded-lg" />
             <div className="text-center">


### PR DESCRIPTION
## Summary
- Enable scroll restoration so detail pages scroll to top on navigation
- Stack detail page layout vertically on mobile, side-by-side on sm+