### PR TITLE
fix: responsive tab breakpoint and light mode styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,8 +23,8 @@
   --card-foreground: oklch(0.22 0.02 260);
   --popover: oklch(0.99 0.005 230);
   --popover-foreground: oklch(0.22 0.02 260);
-  --primary: oklch(0.88 0.08 210);
-  --primary-foreground: oklch(0.18 0.015 270);
+  --primary: oklch(0.5 0.12 220);
+  --primary-foreground: oklch(0.97 0.005 220);
   --secondary: oklch(0.94 0.01 230);
   --secondary-foreground: oklch(0.22 0.02 260);
   --muted: oklch(0.94 0.01 230);
@@ -35,8 +35,8 @@
   --destructive-foreground: oklch(0.58 0.22 28);
   --border: oklch(0.9 0.01 230);
   --input: oklch(0.9 0.01 230);
-  --ring: oklch(0.88 0.08 210);
-  --chart-1: oklch(0.88 0.08 210);
+  --ring: oklch(0.5 0.12 220);
+  --chart-1: oklch(0.5 0.12 220);
   --chart-2: oklch(0.75 0.17 165);
   --chart-3: oklch(0.75 0.15 75);
   --chart-4: oklch(0.6 0.2 300);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -203,7 +203,7 @@ function RootComponent() {
         {showTabs && (
           <>
             {/* Desktop: tab row with icons */}
-            <div className="border-border/50 hidden gap-0 overflow-x-auto border-t px-4 sm:flex">
+            <div className="border-border/50 hidden gap-0 overflow-x-auto border-t px-4 lg:flex">
               {NAV_TABS.map((tab) => {
                 const isActive =
                   currentPath === tab.to || currentPath.startsWith(tab.to + "/")
@@ -232,7 +232,7 @@ function RootComponent() {
               })}
             </div>
             {/* Mobile: select dropdown */}
-            <div className="border-border/50 border-t px-4 py-2 sm:hidden">
+            <div className="border-border/50 border-t px-4 py-2 lg:hidden">
               <Select
                 value={activeTab?.to ?? NAV_TABS[0].to}
                 onValueChange={(v) => navigate({ to: v })}
@@ -258,15 +258,14 @@ function RootComponent() {
       <div
         className={cn(
           "relative flex min-h-screen flex-col",
-          showTabs ? "pt-[6.25rem]" : "pt-14"
+          showTabs ? "pt-[6.75rem] lg:pt-[6.25rem]" : "pt-14"
         )}
       >
         <div
-          className="pointer-events-none fixed inset-0 z-0 bg-center bg-no-repeat opacity-[0.04]"
+          className="pointer-events-none fixed inset-0 z-0 bg-center bg-no-repeat opacity-[0.04] brightness-0 dark:invert"
           style={{
             backgroundImage: "url(/rood-inverse.svg)",
             backgroundSize: "auto 80vh",
-            filter: "brightness(0) invert(1)",
           }}
         />
         <div className="relative z-10 flex flex-1 flex-col">


### PR DESCRIPTION
## Summary
- **Tab row breakpoint**: Changed from `sm` (640px) to `lg` (1024px) so screens below ~1080px use the mobile select dropdown instead of an overflowing/scrolling tab row with 15 tabs
- **Background SVG in light mode**: Replaced inline `filter: brightness(0) invert(1)` with Tailwind `brightness-0 dark:invert` so the rood-inverse watermark renders as black on light backgrounds and white on dark backgrounds
- **Light mode primary color**: Darkened `--primary` from `oklch(0.88 ...)` to `oklch(0.50 ...)` so ice-blue links, MP costs, and icon backgrounds are readable against white. Updated `--primary-foreground`, `--ring`, and `--chart-1` to match

## Test plan
- [x] Verify tab row shows at >= 1024px, mobile select shows below 1024px
- [x] Verify rood-inverse SVG watermark is visible in both dark and light mode
- [x] Verify primary-colored text (links, table headers, badges) is readable in light mode
- [x] Verify icon containers (`bg-primary`) have sufficient contrast in light mode
- [x] Verify dark mode is unchanged
- [x] Build passes (`pnpm build`)