### PR TITLE
Restructure nav: 4 tabs + database page select

### DIFF
--- a/src/components/database-select.tsx
+++ b/src/components/database-select.tsx
@@ -1,0 +1,57 @@
+import { useLocation, useNavigate } from "@tanstack/react-router"
+import { ItemIcon } from "@/components/item-icon"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const DATABASE_PAGES = [
+  { to: "/blades", label: "Blades", icon: "Sword" },
+  { to: "/grips", label: "Grips", icon: "Grip" },
+  { to: "/armor", label: "Armor", icon: "Body" },
+  { to: "/materials", label: "Materials", icon: "Bronze" },
+  { to: "/accessories", label: "Accessories", icon: "Accessory" },
+  { to: "/gems", label: "Gems", icon: "Gem" },
+  { to: "/consumables", label: "Consumables", icon: "Consumable" },
+  { to: "/break-arts", label: "Break Arts", icon: "BreakArt" },
+  { to: "/battle-abilities", label: "Battle Abilities", icon: "BattleAbility" },
+  { to: "/spells", label: "Spells", icon: "Spell" },
+  { to: "/grimoires", label: "Grimoires", icon: "Grimoire" },
+  { to: "/keys", label: "Keys", icon: "Key" },
+  { to: "/sigils", label: "Sigils", icon: "Sigil" },
+  { to: "/workshops", label: "Workshops", icon: "Workshop" },
+]
+
+export function DatabaseSelect() {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const currentPage = DATABASE_PAGES.find(
+    (p) =>
+      location.pathname === p.to || location.pathname.startsWith(p.to + "/")
+  )
+
+  return (
+    <Select
+      value={currentPage?.to ?? DATABASE_PAGES[0].to}
+      onValueChange={(v) => navigate({ to: v })}
+    >
+      <SelectTrigger className="h-9 w-fit">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {DATABASE_PAGES.map((page) => (
+          <SelectItem key={page.to} value={page.to}>
+            <div className="flex items-center gap-2">
+              <ItemIcon type={page.icon} size="sm" />
+              {page.label}
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/src/pages/materials/materials-page.tsx
+++ b/src/pages/materials/materials-page.tsx
@@ -38,7 +38,7 @@ export function MaterialsPage() {
   })
 
   return (
-    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+    <>
       <div>
         <h1 className="text-3xl tracking-wide sm:text-4xl">Materials</h1>
         <p className="text-muted-foreground mt-1 text-sm">
@@ -55,7 +55,7 @@ export function MaterialsPage() {
           ))}
         </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -85,25 +85,25 @@ const ITEM_LINKS = [
   { to: "/workshops" as const, label: "Workshops" },
 ]
 
+const DATABASE_ROUTES = [
+  "/blades",
+  "/grips",
+  "/armor",
+  "/materials",
+  "/accessories",
+  "/gems",
+  "/consumables",
+  "/break-arts",
+  "/battle-abilities",
+  "/spells",
+  "/grimoires",
+  "/keys",
+  "/sigils",
+  "/workshops",
+]
+
 const NAV_TABS = [
-  { to: "/blades" as const, label: "Blades", icon: "Sword" },
-  { to: "/grips" as const, label: "Grips", icon: "Grip" },
-  { to: "/armor" as const, label: "Armor", icon: "Body" },
-  { to: "/materials" as const, label: "Materials", icon: "Bronze" },
-  { to: "/accessories" as const, label: "Accessories", icon: "Accessory" },
-  { to: "/gems" as const, label: "Gems", icon: "Gem" },
-  { to: "/consumables" as const, label: "Consumables", icon: "Consumable" },
-  { to: "/break-arts" as const, label: "Break Arts", icon: "BreakArt" },
-  {
-    to: "/battle-abilities" as const,
-    label: "Battle Abilities",
-    icon: "BattleAbility",
-  },
-  { to: "/spells" as const, label: "Spells", icon: "Spell" },
-  { to: "/grimoires" as const, label: "Grimoires", icon: "Grimoire" },
-  { to: "/keys" as const, label: "Keys", icon: "Key" },
-  { to: "/sigils" as const, label: "Sigils", icon: "Sigil" },
-  { to: "/workshops" as const, label: "Workshops", icon: "Workshop" },
+  { to: "/blades" as const, label: "Game Database", icon: "Sword" },
   { to: "/forge" as const, label: "Forge", icon: "Forge" },
   { to: "/crafting" as const, label: "Crafting", icon: "Crafting" },
   { to: "/material-grid" as const, label: "Material Grid", icon: "Grid" },
@@ -116,9 +116,14 @@ function RootComponent() {
   const navigate = useNavigate()
   const currentPath = matches[matches.length - 1]?.fullPath ?? "/"
   const showTabs = currentPath !== "/"
-  const activeTab = NAV_TABS.find(
-    (t) => currentPath === t.to || currentPath.startsWith(t.to + "/")
+  const isOnDatabaseRoute = DATABASE_ROUTES.some(
+    (r) => currentPath === r || currentPath.startsWith(r + "/")
   )
+  const activeTab = isOnDatabaseRoute
+    ? NAV_TABS[0]
+    : NAV_TABS.find(
+        (t) => currentPath === t.to || currentPath.startsWith(t.to + "/")
+      )
 
   return (
     <>
@@ -214,7 +219,10 @@ function RootComponent() {
             <div className="border-border/50 hidden gap-0 overflow-x-auto border-t px-4 lg:flex">
               {NAV_TABS.map((tab) => {
                 const isActive =
-                  currentPath === tab.to || currentPath.startsWith(tab.to + "/")
+                  tab.to === "/blades"
+                    ? isOnDatabaseRoute
+                    : currentPath === tab.to ||
+                      currentPath.startsWith(tab.to + "/")
                 return (
                   <Link
                     key={tab.to}

--- a/src/routes/accessories/route.tsx
+++ b/src/routes/accessories/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { AccessoriesPage } from "@/pages/accessories/accessories-page"
 
 export const Route = createFileRoute("/accessories")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <AccessoriesPage />
     </div>

--- a/src/routes/armor/route.tsx
+++ b/src/routes/armor/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { ArmorPage } from "@/pages/armor/armor-page"
 
 export const Route = createFileRoute("/armor")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <ArmorPage />
     </div>

--- a/src/routes/battle-abilities/route.tsx
+++ b/src/routes/battle-abilities/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { BattleAbilitiesPage } from "@/pages/battle-abilities/battle-abilities-page"
 
 export const Route = createFileRoute("/battle-abilities")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <BattleAbilitiesPage />
     </div>

--- a/src/routes/blades/route.tsx
+++ b/src/routes/blades/route.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { BladesPage } from "@/pages/blades/blades-page"
 
 export const Route = createFileRoute("/blades")({
@@ -8,6 +9,7 @@ export const Route = createFileRoute("/blades")({
 function BladesLayout() {
   return (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <BladesPage />
     </div>

--- a/src/routes/break-arts/route.tsx
+++ b/src/routes/break-arts/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { BreakArtsPage } from "@/pages/break-arts/break-arts-page"
 
 export const Route = createFileRoute("/break-arts")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <BreakArtsPage />
     </div>

--- a/src/routes/consumables/route.tsx
+++ b/src/routes/consumables/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { ConsumablesPage } from "@/pages/consumables/consumables-page"
 
 export const Route = createFileRoute("/consumables")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <ConsumablesPage />
     </div>

--- a/src/routes/gems/route.tsx
+++ b/src/routes/gems/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { GemsPage } from "@/pages/gems/gems-page"
 
 export const Route = createFileRoute("/gems")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <GemsPage />
     </div>

--- a/src/routes/grimoires/route.tsx
+++ b/src/routes/grimoires/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { GrimoiresPage } from "@/pages/grimoires/grimoires-page"
 
 export const Route = createFileRoute("/grimoires")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <GrimoiresPage />
     </div>

--- a/src/routes/grips/route.tsx
+++ b/src/routes/grips/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { GripsPage } from "@/pages/grips/grips-page"
 
 export const Route = createFileRoute("/grips")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <GripsPage />
     </div>

--- a/src/routes/keys/route.tsx
+++ b/src/routes/keys/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { KeysPage } from "@/pages/keys/keys-page"
 
 export const Route = createFileRoute("/keys")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <KeysPage />
     </div>

--- a/src/routes/materials.tsx
+++ b/src/routes/materials.tsx
@@ -1,6 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { MaterialsPage } from "@/pages/materials/materials-page"
 
 export const Route = createFileRoute("/materials")({
-  component: MaterialsPage,
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
+      <MaterialsPage />
+    </div>
+  ),
 })

--- a/src/routes/sigils/route.tsx
+++ b/src/routes/sigils/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { SigilsPage } from "@/pages/sigils/sigils-page"
 
 export const Route = createFileRoute("/sigils")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <SigilsPage />
     </div>

--- a/src/routes/spells/route.tsx
+++ b/src/routes/spells/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { SpellsPage } from "@/pages/spells/spells-page"
 
 export const Route = createFileRoute("/spells")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <SpellsPage />
     </div>

--- a/src/routes/workshops/route.tsx
+++ b/src/routes/workshops/route.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
 import { WorkshopsPage } from "@/pages/workshops/workshops-page"
 
 export const Route = createFileRoute("/workshops")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
       <Outlet />
       <WorkshopsPage />
     </div>


### PR DESCRIPTION
## Summary
- Reduce tab bar from 17 to 4: Game Database, Forge, Crafting, Material Grid
- Game Database tab active when any database route matches
- DatabaseSelect component at top of every database page for switching
- Desktop header Game Database dropdown kept for quick access
- Mobile select shows only 4 items
- No URL changes

## Test plan
- [ ] Tab bar shows 4 items on desktop
- [ ] Game Database tab highlights on any database page
- [ ] Database select at top of each page works
- [ ] Mobile select shows 4 items
- [ ] All existing URLs still work