### PR TITLE
feat: add chests database page

### DIFF
--- a/src/components/database-select.tsx
+++ b/src/components/database-select.tsx
@@ -22,6 +22,7 @@ const DATABASE_PAGES = [
   { to: "/grimoires", label: "Grimoires", icon: "Grimoire" },
   { to: "/keys", label: "Keys", icon: "Key" },
   { to: "/sigils", label: "Sigils", icon: "Sigil" },
+  { to: "/chests", label: "Chests", icon: "Chest" },
   { to: "/workshops", label: "Workshops", icon: "Workshop" },
   { to: "/characters", label: "Characters", icon: "Character" },
   { to: "/titles", label: "Titles", icon: "Title" },

--- a/src/components/item-icon.tsx
+++ b/src/components/item-icon.tsx
@@ -41,6 +41,7 @@ const ICON_MAP: Record<string, string> = {
   Key: "Key",
   Sigil: "Sigil",
   Grimoire: "Grimoire",
+  Chest: "Gem",
   Workshop: "Workshop",
   Forge: "Forge",
   Crafting: "Crafting",

--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -242,6 +242,27 @@ export interface Ranking {
   requirement: string
 }
 
+export interface ChestItem {
+  id: number
+  chest_id: number
+  item_type: string
+  item_name: string
+  material: string | null
+  gem_slots: number | null
+  quantity: number
+}
+
+export interface Chest {
+  id: number
+  area: string
+  room: string
+  lock_type: string | null
+}
+
+export interface ChestDetail extends Chest {
+  items: ChestItem[]
+}
+
 export interface CraftingRecipe {
   id: number
   category: string
@@ -292,6 +313,8 @@ export const gameApi = {
   sigils: () => fetchApi<Sigil[]>("/sigils?limit=200"),
   grimoires: () => fetchApi<Grimoire[]>("/grimoires?limit=500"),
   grimoire: (id: number) => fetchApi<GrimoireDetail>(`/grimoires/${id}`),
+  chests: () => fetchApi<Chest[]>("/chests?limit=500"),
+  chest: (id: number) => fetchApi<ChestDetail>(`/chests/${id}`),
   workshops: () => fetchApi<Workshop[]>("/workshops?limit=200"),
   characters: () => fetchApi<Character[]>("/characters?limit=200"),
   character: (id: number) => fetchApi<Character>(`/characters/${id}`),

--- a/src/pages/chests/chests-page.tsx
+++ b/src/pages/chests/chests-page.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable } from "@/components/data-table"
+import { ItemIcon } from "@/components/item-icon"
+import { Badge } from "@/components/ui/badge"
+import { gameApi, type Chest } from "@/lib/game-api"
+
+const columns: ColumnDef<Chest & { _display: string }>[] = [
+  {
+    accessorKey: "area",
+    header: "Area",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <ItemIcon type="Chest" />
+        <span className="font-medium">{row.original.area}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "room",
+    header: "Room",
+    cell: ({ getValue }) => {
+      const v = getValue<string>()
+      return <span className="text-sm">{v}</span>
+    },
+  },
+  {
+    accessorKey: "lock_type",
+    header: "Lock",
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>()
+      if (!v) return null
+      return (
+        <Badge variant="outline" className="text-xs">
+          {v}
+        </Badge>
+      )
+    },
+  },
+]
+
+const AREA_OPTIONS = [
+  "Wine Cellar",
+  "Catacombs",
+  "Sanctum",
+  "Abandoned Mines B1",
+  "Abandoned Mines B2",
+  "Limestone Quarry",
+  "Temple of Kiltia",
+  "Great Cathedral L1",
+  "Great Cathedral L2",
+  "Forgotten Pathway",
+  "Escapeway",
+  "Iron Maiden B1",
+  "Iron Maiden B2",
+  "Iron Maiden B3",
+  "Undercity West",
+  "Undercity East",
+  "The Keep",
+  "Snowfly Forest",
+  "Snowfly Forest East",
+  "Town Centre South",
+  "Town Centre East",
+]
+
+export function ChestsPage() {
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["chests"],
+    queryFn: gameApi.chests,
+  })
+
+  const enriched = useMemo(
+    () => data.map((c) => ({ ...c, _display: `${c.area} ${c.room}` })),
+    [data]
+  )
+
+  return (
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search chests..."
+      isLoading={isLoading}
+      getRowLink={(row) => ({
+        to: "/chests/$id",
+        params: { id: String(row.original.id) },
+      })}
+      filters={[
+        {
+          column: "area",
+          label: "Area",
+          options: AREA_OPTIONS,
+        },
+      ]}
+    />
+  )
+}

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -42,6 +42,10 @@ export function HomePage() {
     queryKey: ["grimoires"],
     queryFn: gameApi.grimoires,
   })
+  const { data: chests = [] } = useQuery({
+    queryKey: ["chests"],
+    queryFn: gameApi.chests,
+  })
   const { data: workshops = [] } = useQuery({
     queryKey: ["workshops"],
     queryFn: gameApi.workshops,
@@ -142,6 +146,12 @@ export function HomePage() {
       label: "Sigils",
       icon: "Sigil",
       count: sigils.length,
+    },
+    {
+      to: "/chests" as const,
+      label: "Chests",
+      icon: "Chest",
+      count: chests.length,
     },
     {
       to: "/workshops" as const,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as GrimoiresRouteRouteImport } from './routes/grimoires/route'
 import { Route as GemsRouteRouteImport } from './routes/gems/route'
 import { Route as ForgeRouteRouteImport } from './routes/forge/route'
 import { Route as ConsumablesRouteRouteImport } from './routes/consumables/route'
+import { Route as ChestsRouteRouteImport } from './routes/chests/route'
 import { Route as CharactersRouteRouteImport } from './routes/characters/route'
 import { Route as BreakArtsRouteRouteImport } from './routes/break-arts/route'
 import { Route as BladesRouteRouteImport } from './routes/blades/route'
@@ -41,6 +42,7 @@ import { Route as GemsIndexRouteImport } from './routes/gems/index'
 import { Route as ForgeIndexRouteImport } from './routes/forge/index'
 import { Route as CraftingIndexRouteImport } from './routes/crafting/index'
 import { Route as ConsumablesIndexRouteImport } from './routes/consumables/index'
+import { Route as ChestsIndexRouteImport } from './routes/chests/index'
 import { Route as CharactersIndexRouteImport } from './routes/characters/index'
 import { Route as BreakArtsIndexRouteImport } from './routes/break-arts/index'
 import { Route as BladesIndexRouteImport } from './routes/blades/index'
@@ -57,6 +59,7 @@ import { Route as GripsIdRouteImport } from './routes/grips/$id'
 import { Route as GrimoiresIdRouteImport } from './routes/grimoires/$id'
 import { Route as GemsIdRouteImport } from './routes/gems/$id'
 import { Route as ConsumablesIdRouteImport } from './routes/consumables/$id'
+import { Route as ChestsIdRouteImport } from './routes/chests/$id'
 import { Route as CharactersIdRouteImport } from './routes/characters/$id'
 import { Route as BreakArtsIdRouteImport } from './routes/break-arts/$id'
 import { Route as BladesIdRouteImport } from './routes/blades/$id'
@@ -127,6 +130,11 @@ const ForgeRouteRoute = ForgeRouteRouteImport.update({
 const ConsumablesRouteRoute = ConsumablesRouteRouteImport.update({
   id: '/consumables',
   path: '/consumables',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChestsRouteRoute = ChestsRouteRouteImport.update({
+  id: '/chests',
+  path: '/chests',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CharactersRouteRoute = CharactersRouteRouteImport.update({
@@ -224,6 +232,11 @@ const ConsumablesIndexRoute = ConsumablesIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ConsumablesRouteRoute,
 } as any)
+const ChestsIndexRoute = ChestsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ChestsRouteRoute,
+} as any)
 const CharactersIndexRoute = CharactersIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -304,6 +317,11 @@ const ConsumablesIdRoute = ConsumablesIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => ConsumablesRouteRoute,
 } as any)
+const ChestsIdRoute = ChestsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ChestsRouteRoute,
+} as any)
 const CharactersIdRoute = CharactersIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -343,6 +361,7 @@ export interface FileRoutesByFullPath {
   '/blades': typeof BladesRouteRouteWithChildren
   '/break-arts': typeof BreakArtsRouteRouteWithChildren
   '/characters': typeof CharactersRouteRouteWithChildren
+  '/chests': typeof ChestsRouteRouteWithChildren
   '/consumables': typeof ConsumablesRouteRouteWithChildren
   '/forge': typeof ForgeRouteRouteWithChildren
   '/gems': typeof GemsRouteRouteWithChildren
@@ -362,6 +381,7 @@ export interface FileRoutesByFullPath {
   '/blades/$id': typeof BladesIdRoute
   '/break-arts/$id': typeof BreakArtsIdRoute
   '/characters/$id': typeof CharactersIdRoute
+  '/chests/$id': typeof ChestsIdRoute
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
   '/grimoires/$id': typeof GrimoiresIdRoute
@@ -378,6 +398,7 @@ export interface FileRoutesByFullPath {
   '/blades/': typeof BladesIndexRoute
   '/break-arts/': typeof BreakArtsIndexRoute
   '/characters/': typeof CharactersIndexRoute
+  '/chests/': typeof ChestsIndexRoute
   '/consumables/': typeof ConsumablesIndexRoute
   '/crafting/': typeof CraftingIndexRoute
   '/forge/': typeof ForgeIndexRoute
@@ -401,6 +422,7 @@ export interface FileRoutesByTo {
   '/blades/$id': typeof BladesIdRoute
   '/break-arts/$id': typeof BreakArtsIdRoute
   '/characters/$id': typeof CharactersIdRoute
+  '/chests/$id': typeof ChestsIdRoute
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
   '/grimoires/$id': typeof GrimoiresIdRoute
@@ -417,6 +439,7 @@ export interface FileRoutesByTo {
   '/blades': typeof BladesIndexRoute
   '/break-arts': typeof BreakArtsIndexRoute
   '/characters': typeof CharactersIndexRoute
+  '/chests': typeof ChestsIndexRoute
   '/consumables': typeof ConsumablesIndexRoute
   '/crafting': typeof CraftingIndexRoute
   '/forge': typeof ForgeIndexRoute
@@ -439,6 +462,7 @@ export interface FileRoutesById {
   '/blades': typeof BladesRouteRouteWithChildren
   '/break-arts': typeof BreakArtsRouteRouteWithChildren
   '/characters': typeof CharactersRouteRouteWithChildren
+  '/chests': typeof ChestsRouteRouteWithChildren
   '/consumables': typeof ConsumablesRouteRouteWithChildren
   '/forge': typeof ForgeRouteRouteWithChildren
   '/gems': typeof GemsRouteRouteWithChildren
@@ -458,6 +482,7 @@ export interface FileRoutesById {
   '/blades/$id': typeof BladesIdRoute
   '/break-arts/$id': typeof BreakArtsIdRoute
   '/characters/$id': typeof CharactersIdRoute
+  '/chests/$id': typeof ChestsIdRoute
   '/consumables/$id': typeof ConsumablesIdRoute
   '/gems/$id': typeof GemsIdRoute
   '/grimoires/$id': typeof GrimoiresIdRoute
@@ -474,6 +499,7 @@ export interface FileRoutesById {
   '/blades/': typeof BladesIndexRoute
   '/break-arts/': typeof BreakArtsIndexRoute
   '/characters/': typeof CharactersIndexRoute
+  '/chests/': typeof ChestsIndexRoute
   '/consumables/': typeof ConsumablesIndexRoute
   '/crafting/': typeof CraftingIndexRoute
   '/forge/': typeof ForgeIndexRoute
@@ -497,6 +523,7 @@ export interface FileRouteTypes {
     | '/blades'
     | '/break-arts'
     | '/characters'
+    | '/chests'
     | '/consumables'
     | '/forge'
     | '/gems'
@@ -516,6 +543,7 @@ export interface FileRouteTypes {
     | '/blades/$id'
     | '/break-arts/$id'
     | '/characters/$id'
+    | '/chests/$id'
     | '/consumables/$id'
     | '/gems/$id'
     | '/grimoires/$id'
@@ -532,6 +560,7 @@ export interface FileRouteTypes {
     | '/blades/'
     | '/break-arts/'
     | '/characters/'
+    | '/chests/'
     | '/consumables/'
     | '/crafting/'
     | '/forge/'
@@ -555,6 +584,7 @@ export interface FileRouteTypes {
     | '/blades/$id'
     | '/break-arts/$id'
     | '/characters/$id'
+    | '/chests/$id'
     | '/consumables/$id'
     | '/gems/$id'
     | '/grimoires/$id'
@@ -571,6 +601,7 @@ export interface FileRouteTypes {
     | '/blades'
     | '/break-arts'
     | '/characters'
+    | '/chests'
     | '/consumables'
     | '/crafting'
     | '/forge'
@@ -592,6 +623,7 @@ export interface FileRouteTypes {
     | '/blades'
     | '/break-arts'
     | '/characters'
+    | '/chests'
     | '/consumables'
     | '/forge'
     | '/gems'
@@ -611,6 +643,7 @@ export interface FileRouteTypes {
     | '/blades/$id'
     | '/break-arts/$id'
     | '/characters/$id'
+    | '/chests/$id'
     | '/consumables/$id'
     | '/gems/$id'
     | '/grimoires/$id'
@@ -627,6 +660,7 @@ export interface FileRouteTypes {
     | '/blades/'
     | '/break-arts/'
     | '/characters/'
+    | '/chests/'
     | '/consumables/'
     | '/crafting/'
     | '/forge/'
@@ -649,6 +683,7 @@ export interface RootRouteChildren {
   BladesRouteRoute: typeof BladesRouteRouteWithChildren
   BreakArtsRouteRoute: typeof BreakArtsRouteRouteWithChildren
   CharactersRouteRoute: typeof CharactersRouteRouteWithChildren
+  ChestsRouteRoute: typeof ChestsRouteRouteWithChildren
   ConsumablesRouteRoute: typeof ConsumablesRouteRouteWithChildren
   ForgeRouteRoute: typeof ForgeRouteRouteWithChildren
   GemsRouteRoute: typeof GemsRouteRouteWithChildren
@@ -756,6 +791,13 @@ declare module '@tanstack/react-router' {
       path: '/consumables'
       fullPath: '/consumables'
       preLoaderRoute: typeof ConsumablesRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chests': {
+      id: '/chests'
+      path: '/chests'
+      fullPath: '/chests'
+      preLoaderRoute: typeof ChestsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/characters': {
@@ -891,6 +933,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ConsumablesIndexRouteImport
       parentRoute: typeof ConsumablesRouteRoute
     }
+    '/chests/': {
+      id: '/chests/'
+      path: '/'
+      fullPath: '/chests/'
+      preLoaderRoute: typeof ChestsIndexRouteImport
+      parentRoute: typeof ChestsRouteRoute
+    }
     '/characters/': {
       id: '/characters/'
       path: '/'
@@ -1002,6 +1051,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/consumables/$id'
       preLoaderRoute: typeof ConsumablesIdRouteImport
       parentRoute: typeof ConsumablesRouteRoute
+    }
+    '/chests/$id': {
+      id: '/chests/$id'
+      path: '/$id'
+      fullPath: '/chests/$id'
+      preLoaderRoute: typeof ChestsIdRouteImport
+      parentRoute: typeof ChestsRouteRoute
     }
     '/characters/$id': {
       id: '/characters/$id'
@@ -1128,6 +1184,20 @@ const CharactersRouteRouteChildren: CharactersRouteRouteChildren = {
 
 const CharactersRouteRouteWithChildren = CharactersRouteRoute._addFileChildren(
   CharactersRouteRouteChildren,
+)
+
+interface ChestsRouteRouteChildren {
+  ChestsIdRoute: typeof ChestsIdRoute
+  ChestsIndexRoute: typeof ChestsIndexRoute
+}
+
+const ChestsRouteRouteChildren: ChestsRouteRouteChildren = {
+  ChestsIdRoute: ChestsIdRoute,
+  ChestsIndexRoute: ChestsIndexRoute,
+}
+
+const ChestsRouteRouteWithChildren = ChestsRouteRoute._addFileChildren(
+  ChestsRouteRouteChildren,
 )
 
 interface ConsumablesRouteRouteChildren {
@@ -1289,6 +1359,7 @@ const rootRouteChildren: RootRouteChildren = {
   BladesRouteRoute: BladesRouteRouteWithChildren,
   BreakArtsRouteRoute: BreakArtsRouteRouteWithChildren,
   CharactersRouteRoute: CharactersRouteRouteWithChildren,
+  ChestsRouteRoute: ChestsRouteRouteWithChildren,
   ConsumablesRouteRoute: ConsumablesRouteRouteWithChildren,
   ForgeRouteRoute: ForgeRouteRouteWithChildren,
   GemsRouteRoute: GemsRouteRouteWithChildren,

--- a/src/routes/chests/$id.tsx
+++ b/src/routes/chests/$id.tsx
@@ -1,0 +1,223 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { Lock, X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ItemIcon } from "@/components/item-icon"
+import { MaterialBadge } from "@/components/stat-display"
+import {
+  gameApi,
+  type ChestItem,
+  type Blade,
+  type Armor,
+  type Grip,
+  type Gem,
+  type Consumable,
+  type Grimoire,
+} from "@/lib/game-api"
+
+export const Route = createFileRoute("/chests/$id")({
+  component: ChestDetail,
+})
+
+/** Map item_type to the icon type string used by ItemIcon */
+const ICON_MAP: Record<string, string> = {
+  blade: "Sword",
+  grip: "Grip",
+  shield: "Shield",
+  armor: "Body",
+  gem: "Gem",
+  grimoire: "Grimoire",
+  sigil: "Sigil",
+  key: "Key",
+  consumable: "Consumable",
+  accessory: "Accessory",
+}
+
+/** Map item_type to the route prefix for linking */
+const ROUTE_MAP: Record<string, string> = {
+  blade: "/blades",
+  grip: "/grips",
+  shield: "/armor",
+  armor: "/armor",
+  gem: "/gems",
+  grimoire: "/grimoires",
+  sigil: "/sigils",
+  key: "/keys",
+  consumable: "/consumables",
+  accessory: "/armor",
+}
+
+type NamedItem = { id: number; name: string }
+
+function buildLookup(items: NamedItem[]): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const item of items) {
+    map.set(item.name, item.id)
+  }
+  return map
+}
+
+function ChestDetail() {
+  const { id } = Route.useParams()
+
+  const { data: chest } = useQuery({
+    queryKey: ["chest", id],
+    queryFn: () => gameApi.chest(Number(id)),
+  })
+
+  // Fetch all game data for name-based linking
+  const { data: blades = [] } = useQuery<Blade[]>({
+    queryKey: ["blades"],
+    queryFn: gameApi.blades,
+  })
+  const { data: armor = [] } = useQuery<Armor[]>({
+    queryKey: ["armor"],
+    queryFn: gameApi.armor,
+  })
+  const { data: grips = [] } = useQuery<Grip[]>({
+    queryKey: ["grips"],
+    queryFn: gameApi.grips,
+  })
+  const { data: gems = [] } = useQuery<Gem[]>({
+    queryKey: ["gems"],
+    queryFn: gameApi.gems,
+  })
+  const { data: consumables = [] } = useQuery<Consumable[]>({
+    queryKey: ["consumables"],
+    queryFn: gameApi.consumables,
+  })
+  const { data: grimoires = [] } = useQuery<Grimoire[]>({
+    queryKey: ["grimoires"],
+    queryFn: gameApi.grimoires,
+  })
+  const { data: sigils = [] } = useQuery({
+    queryKey: ["sigils"],
+    queryFn: gameApi.sigils,
+  })
+  const { data: keys = [] } = useQuery({
+    queryKey: ["keys"],
+    queryFn: gameApi.keys,
+  })
+
+  if (!chest) return null
+
+  // Build lookup maps by name
+  const lookups: Record<string, Map<string, number>> = {
+    blade: buildLookup(blades),
+    grip: buildLookup(grips),
+    shield: buildLookup(armor.filter((a) => a.armor_type === "Shield")),
+    armor: buildLookup(armor),
+    gem: buildLookup(gems),
+    consumable: buildLookup(consumables),
+    grimoire: buildLookup(grimoires),
+    sigil: buildLookup(sigils),
+    key: buildLookup(keys),
+    accessory: buildLookup(armor.filter((a) => a.armor_type === "Accessory")),
+  }
+
+  function getItemLink(item: ChestItem): string | null {
+    const routePrefix = ROUTE_MAP[item.item_type]
+    if (!routePrefix) return null
+    const lookup = lookups[item.item_type]
+    if (!lookup) return null
+    const itemId = lookup.get(item.item_name)
+    if (itemId == null) return null
+    return `${routePrefix}/${itemId}`
+  }
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-3xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/chests"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+
+        <div className="flex flex-col gap-6 sm:flex-row">
+          <div className="flex flex-col items-center gap-3">
+            <ItemIcon type="Chest" size="lg" className="rounded-lg" />
+            <div className="text-center">
+              <h2 className="text-2xl font-medium tracking-wide">
+                {chest.room}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                {chest.area}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-1 flex-col gap-4">
+            {chest.lock_type && (
+              <div className="flex items-center gap-2 text-sm">
+                <Lock className="text-muted-foreground size-4" />
+                <Badge variant="outline">{chest.lock_type}</Badge>
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <p className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+                Contents ({chest.items.length} items)
+              </p>
+              <div className="divide-border divide-y">
+                {chest.items.map((item) => {
+                  const link = getItemLink(item)
+                  const content = (
+                    <div className="flex items-center gap-3 py-2">
+                      <ItemIcon
+                        type={ICON_MAP[item.item_type] ?? "Gem"}
+                        size="sm"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <span className="text-sm font-medium">
+                          {item.item_name}
+                        </span>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+                          {item.material && (
+                            <MaterialBadge mat={item.material} />
+                          )}
+                          {item.gem_slots != null && item.gem_slots > 0 && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              {item.gem_slots} gem{" "}
+                              {item.gem_slots === 1 ? "slot" : "slots"}
+                            </Badge>
+                          )}
+                          {item.quantity > 1 && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              x{item.quantity}
+                            </Badge>
+                          )}
+                          <span className="text-muted-foreground text-[10px] capitalize">
+                            {item.item_type}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  )
+
+                  if (link) {
+                    return (
+                      <Link
+                        key={item.id}
+                        to={link}
+                        className="hover:bg-muted/50 -mx-2 block rounded px-2 transition-colors"
+                      >
+                        {content}
+                      </Link>
+                    )
+                  }
+
+                  return <div key={item.id}>{content}</div>
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/chests/index.tsx
+++ b/src/routes/chests/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/chests/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Chests</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        52 treasure chests scattered throughout Lea Monde — click for contents
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/chests/route.tsx
+++ b/src/routes/chests/route.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
+import { ChestsPage } from "@/pages/chests/chests-page"
+
+export const Route = createFileRoute("/chests")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
+      <Outlet />
+      <ChestsPage />
+    </div>
+  ),
+})


### PR DESCRIPTION
## Summary
- Add Chest list page with DataTable (Area, Room, Lock Type columns) and area filter
- Add Chest detail page showing all items with icons, material badges, gem slot/quantity indicators, and clickable cross-links to blades, armor, grips, gems, consumables, grimoires, sigils, and keys
- Add Chest/ChestItem interfaces and API functions to game-api.ts
- Add "Chests" to DatabaseSelect dropdown and homepage DB_CARDS

Depends on API PR: https://github.com/ag-tech-group/vagrant-story-api/pull/38 (merged)

## Test plan
- [ ] `/chests` shows 52 chests in a paginated table with area, room, lock type
- [ ] Area filter works (e.g. filter to "Iron Maiden B1")
- [ ] Clicking a row navigates to `/chests/{id}` detail view
- [ ] Detail view shows room name, area, lock type badge (if locked), and all items
- [ ] Items display correct icons, material badges, gem slots, and quantity
- [ ] Clickable items link to the correct detail pages (blades, armor, etc.)
- [ ] "Chests" appears in DatabaseSelect dropdown and homepage

Closes #52