### PR TITLE
Fix chest detail width, homepage order, gem linking

### DIFF
--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -148,16 +148,16 @@ export function HomePage() {
       count: sigils.length,
     },
     {
-      to: "/chests" as const,
-      label: "Chests",
-      icon: "Chest",
-      count: chests.length,
-    },
-    {
       to: "/workshops" as const,
       label: "Workshops",
       icon: "Workshop",
       count: workshops.length,
+    },
+    {
+      to: "/chests" as const,
+      label: "Chests",
+      icon: "Chest",
+      count: chests.length,
     },
     {
       to: "/characters" as const,

--- a/src/routes/chests/$id.tsx
+++ b/src/routes/chests/$id.tsx
@@ -121,13 +121,22 @@ function ChestDetail() {
     if (!routePrefix) return null
     const lookup = lookups[item.item_type]
     if (!lookup) return null
-    const itemId = lookup.get(item.item_name)
+    let itemId = lookup.get(item.item_name)
+    // Gem chest items often have a " Gem" suffix (e.g. "Braveheart Gem")
+    // that the gems table doesn't include in the name
+    if (
+      itemId == null &&
+      item.item_type === "gem" &&
+      item.item_name.endsWith(" Gem")
+    ) {
+      itemId = lookup.get(item.item_name.slice(0, -4))
+    }
     if (itemId == null) return null
     return `${routePrefix}/${itemId}`
   }
 
   return (
-    <Card className="border-primary/30 mx-auto max-w-3xl">
+    <Card className="border-primary/30 mx-auto max-w-4xl">
       <CardContent className="pt-6">
         <div className="flex w-full justify-end">
           <Link


### PR DESCRIPTION
## Summary
- Reorder homepage DB_CARDS so Workshops appears before Chests, matching the database-select dropdown order
- Widen chest detail card from `max-w-3xl` to `max-w-4xl` so the items column has more room
- Fix gem linking in chest detail: strip " Gem" suffix from chest item names when looking up gems (e.g. "Braveheart Gem" now links to the "Braveheart" gem)

## Test plan
- [ ] Verify homepage cards show Workshops before Chests
- [ ] Verify chest detail page is wider and items column has more space
- [ ] Verify gem items in chest detail link to the correct gem detail page