### PR TITLE
feat: add areas page with rooms and cross-links

### DIFF
--- a/src/components/database-select.tsx
+++ b/src/components/database-select.tsx
@@ -24,6 +24,7 @@ const DATABASE_PAGES = [
   { to: "/sigils", label: "Sigils", icon: "Sigil" },
   { to: "/workshops", label: "Workshops", icon: "Workshop" },
   { to: "/chests", label: "Chests", icon: "Chest" },
+  { to: "/areas", label: "Areas", icon: "Area" },
   { to: "/characters", label: "Characters", icon: "Character" },
   { to: "/titles", label: "Titles", icon: "Title" },
   { to: "/rankings", label: "Rankings", icon: "Ranking" },

--- a/src/components/item-icon.tsx
+++ b/src/components/item-icon.tsx
@@ -42,6 +42,7 @@ const ICON_MAP: Record<string, string> = {
   Sigil: "Sigil",
   Grimoire: "Grimoire",
   Chest: "Chest",
+  Area: "Workshop",
   Workshop: "Workshop",
   Forge: "Forge",
   Crafting: "Crafting",

--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -153,11 +153,30 @@ export interface Spell {
   grimoire: string
 }
 
+export interface Area {
+  id: number
+  name: string
+}
+
+export interface Room {
+  id: number
+  name: string
+  area_id: number
+  area_name: string
+}
+
+export interface AreaDetail {
+  id: number
+  name: string
+  rooms: Room[]
+}
+
 export interface Key {
   id: number
   name: string
   area: string
   room: string
+  room_id: number | null
   source: string
   locations_used: string
 }
@@ -167,6 +186,7 @@ export interface Sigil {
   name: string
   area: string
   room: string
+  room_id: number | null
   source: string
   door_unlocks: string
 }
@@ -187,6 +207,7 @@ export interface GrimoireDetail {
   spell_name: string
   area: string
   room: string
+  room_id: number | null
   source: string
   drop_rate: string
   repeatable: boolean
@@ -196,6 +217,7 @@ export interface Workshop {
   id: number
   name: string
   area: string
+  room_id: number | null
   available_materials: string
   description: string
 }
@@ -256,6 +278,7 @@ export interface Chest {
   id: number
   area: string
   room: string
+  room_id: number | null
   lock_type: string | null
 }
 
@@ -293,6 +316,10 @@ async function fetchApi<T>(path: string): Promise<T> {
 }
 
 export const gameApi = {
+  areas: () => fetchApi<Area[]>("/areas?limit=200"),
+  area: (id: number) => fetchApi<AreaDetail>(`/areas/${id}`),
+  rooms: () => fetchApi<Room[]>("/rooms?limit=500"),
+  room: (id: number) => fetchApi<Room>(`/rooms/${id}`),
   blades: () => fetchApi<Blade[]>("/blades?limit=200"),
   blade: (id: number) => fetchApi<Blade>(`/blades/${id}`),
   armor: () => fetchApi<Armor[]>("/armor?limit=200"),

--- a/src/pages/areas/areas-page.tsx
+++ b/src/pages/areas/areas-page.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type ColumnDef } from "@tanstack/react-table"
+import { DataTable } from "@/components/data-table"
+import { ItemIcon } from "@/components/item-icon"
+import { gameApi, type Area, type Room } from "@/lib/game-api"
+
+type AreaRow = Area & { room_count: number; _display: string }
+
+export function AreasPage() {
+  const { data: areas = [], isLoading: areasLoading } = useQuery({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
+  const { data: rooms = [], isLoading: roomsLoading } = useQuery({
+    queryKey: ["rooms"],
+    queryFn: gameApi.rooms,
+  })
+
+  const enriched = useMemo(() => {
+    const countByArea = new Map<number, number>()
+    rooms.forEach((r: Room) => {
+      countByArea.set(r.area_id, (countByArea.get(r.area_id) || 0) + 1)
+    })
+    return areas.map((a) => ({
+      ...a,
+      room_count: countByArea.get(a.id) || 0,
+      _display: a.name,
+    }))
+  }, [areas, rooms])
+
+  const columns: ColumnDef<AreaRow>[] = useMemo(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Area",
+        cell: ({ row }) => (
+          <div className="flex items-center gap-3">
+            <ItemIcon type="Area" />
+            <span className="font-medium">{row.original.name}</span>
+          </div>
+        ),
+      },
+      {
+        accessorKey: "room_count",
+        header: "Rooms",
+        cell: ({ getValue }) => {
+          const v = getValue<number>()
+          return (
+            <span className="text-muted-foreground text-sm">
+              {v} {v === 1 ? "room" : "rooms"}
+            </span>
+          )
+        },
+      },
+    ],
+    []
+  )
+
+  return (
+    <DataTable
+      data={enriched}
+      columns={columns}
+      searchPlaceholder="Search areas..."
+      isLoading={areasLoading || roomsLoading}
+      getRowLink={(row) => ({
+        to: "/areas/$id",
+        params: { id: String(row.original.id) },
+      })}
+    />
+  )
+}

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -50,6 +50,10 @@ export function HomePage() {
     queryKey: ["workshops"],
     queryFn: gameApi.workshops,
   })
+  const { data: areas = [] } = useQuery({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
   const { data: materials = [] } = useQuery({
     queryKey: ["materials"],
     queryFn: gameApi.materials,
@@ -158,6 +162,12 @@ export function HomePage() {
       label: "Chests",
       icon: "Chest",
       count: chests.length,
+    },
+    {
+      to: "/areas" as const,
+      label: "Areas",
+      icon: "Area",
+      count: areas.length,
     },
     {
       to: "/characters" as const,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as BreakArtsRouteRouteImport } from './routes/break-arts/route'
 import { Route as BladesRouteRouteImport } from './routes/blades/route'
 import { Route as BattleAbilitiesRouteRouteImport } from './routes/battle-abilities/route'
 import { Route as ArmorRouteRouteImport } from './routes/armor/route'
+import { Route as AreasRouteRouteImport } from './routes/areas/route'
 import { Route as AccessoriesRouteRouteImport } from './routes/accessories/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkshopsIndexRouteImport } from './routes/workshops/index'
@@ -48,6 +49,7 @@ import { Route as BreakArtsIndexRouteImport } from './routes/break-arts/index'
 import { Route as BladesIndexRouteImport } from './routes/blades/index'
 import { Route as BattleAbilitiesIndexRouteImport } from './routes/battle-abilities/index'
 import { Route as ArmorIndexRouteImport } from './routes/armor/index'
+import { Route as AreasIndexRouteImport } from './routes/areas/index'
 import { Route as AccessoriesIndexRouteImport } from './routes/accessories/index'
 import { Route as WorkshopsIdRouteImport } from './routes/workshops/$id'
 import { Route as TitlesIdRouteImport } from './routes/titles/$id'
@@ -65,6 +67,7 @@ import { Route as BreakArtsIdRouteImport } from './routes/break-arts/$id'
 import { Route as BladesIdRouteImport } from './routes/blades/$id'
 import { Route as BattleAbilitiesIdRouteImport } from './routes/battle-abilities/$id'
 import { Route as ArmorIdRouteImport } from './routes/armor/$id'
+import { Route as AreasIdRouteImport } from './routes/areas/$id'
 import { Route as AccessoriesIdRouteImport } from './routes/accessories/$id'
 
 const MaterialsRoute = MaterialsRouteImport.update({
@@ -160,6 +163,11 @@ const BattleAbilitiesRouteRoute = BattleAbilitiesRouteRouteImport.update({
 const ArmorRouteRoute = ArmorRouteRouteImport.update({
   id: '/armor',
   path: '/armor',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AreasRouteRoute = AreasRouteRouteImport.update({
+  id: '/areas',
+  path: '/areas',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AccessoriesRouteRoute = AccessoriesRouteRouteImport.update({
@@ -262,6 +270,11 @@ const ArmorIndexRoute = ArmorIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ArmorRouteRoute,
 } as any)
+const AreasIndexRoute = AreasIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AreasRouteRoute,
+} as any)
 const AccessoriesIndexRoute = AccessoriesIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -347,6 +360,11 @@ const ArmorIdRoute = ArmorIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => ArmorRouteRoute,
 } as any)
+const AreasIdRoute = AreasIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => AreasRouteRoute,
+} as any)
 const AccessoriesIdRoute = AccessoriesIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -356,6 +374,7 @@ const AccessoriesIdRoute = AccessoriesIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/accessories': typeof AccessoriesRouteRouteWithChildren
+  '/areas': typeof AreasRouteRouteWithChildren
   '/armor': typeof ArmorRouteRouteWithChildren
   '/battle-abilities': typeof BattleAbilitiesRouteRouteWithChildren
   '/blades': typeof BladesRouteRouteWithChildren
@@ -376,6 +395,7 @@ export interface FileRoutesByFullPath {
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
   '/accessories/$id': typeof AccessoriesIdRoute
+  '/areas/$id': typeof AreasIdRoute
   '/armor/$id': typeof ArmorIdRoute
   '/battle-abilities/$id': typeof BattleAbilitiesIdRoute
   '/blades/$id': typeof BladesIdRoute
@@ -393,6 +413,7 @@ export interface FileRoutesByFullPath {
   '/titles/$id': typeof TitlesIdRoute
   '/workshops/$id': typeof WorkshopsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
+  '/areas/': typeof AreasIndexRoute
   '/armor/': typeof ArmorIndexRoute
   '/battle-abilities/': typeof BattleAbilitiesIndexRoute
   '/blades/': typeof BladesIndexRoute
@@ -417,6 +438,7 @@ export interface FileRoutesByTo {
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
   '/accessories/$id': typeof AccessoriesIdRoute
+  '/areas/$id': typeof AreasIdRoute
   '/armor/$id': typeof ArmorIdRoute
   '/battle-abilities/$id': typeof BattleAbilitiesIdRoute
   '/blades/$id': typeof BladesIdRoute
@@ -434,6 +456,7 @@ export interface FileRoutesByTo {
   '/titles/$id': typeof TitlesIdRoute
   '/workshops/$id': typeof WorkshopsIdRoute
   '/accessories': typeof AccessoriesIndexRoute
+  '/areas': typeof AreasIndexRoute
   '/armor': typeof ArmorIndexRoute
   '/battle-abilities': typeof BattleAbilitiesIndexRoute
   '/blades': typeof BladesIndexRoute
@@ -457,6 +480,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/accessories': typeof AccessoriesRouteRouteWithChildren
+  '/areas': typeof AreasRouteRouteWithChildren
   '/armor': typeof ArmorRouteRouteWithChildren
   '/battle-abilities': typeof BattleAbilitiesRouteRouteWithChildren
   '/blades': typeof BladesRouteRouteWithChildren
@@ -477,6 +501,7 @@ export interface FileRoutesById {
   '/material-grid': typeof MaterialGridRoute
   '/materials': typeof MaterialsRoute
   '/accessories/$id': typeof AccessoriesIdRoute
+  '/areas/$id': typeof AreasIdRoute
   '/armor/$id': typeof ArmorIdRoute
   '/battle-abilities/$id': typeof BattleAbilitiesIdRoute
   '/blades/$id': typeof BladesIdRoute
@@ -494,6 +519,7 @@ export interface FileRoutesById {
   '/titles/$id': typeof TitlesIdRoute
   '/workshops/$id': typeof WorkshopsIdRoute
   '/accessories/': typeof AccessoriesIndexRoute
+  '/areas/': typeof AreasIndexRoute
   '/armor/': typeof ArmorIndexRoute
   '/battle-abilities/': typeof BattleAbilitiesIndexRoute
   '/blades/': typeof BladesIndexRoute
@@ -518,6 +544,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/accessories'
+    | '/areas'
     | '/armor'
     | '/battle-abilities'
     | '/blades'
@@ -538,6 +565,7 @@ export interface FileRouteTypes {
     | '/material-grid'
     | '/materials'
     | '/accessories/$id'
+    | '/areas/$id'
     | '/armor/$id'
     | '/battle-abilities/$id'
     | '/blades/$id'
@@ -555,6 +583,7 @@ export interface FileRouteTypes {
     | '/titles/$id'
     | '/workshops/$id'
     | '/accessories/'
+    | '/areas/'
     | '/armor/'
     | '/battle-abilities/'
     | '/blades/'
@@ -579,6 +608,7 @@ export interface FileRouteTypes {
     | '/material-grid'
     | '/materials'
     | '/accessories/$id'
+    | '/areas/$id'
     | '/armor/$id'
     | '/battle-abilities/$id'
     | '/blades/$id'
@@ -596,6 +626,7 @@ export interface FileRouteTypes {
     | '/titles/$id'
     | '/workshops/$id'
     | '/accessories'
+    | '/areas'
     | '/armor'
     | '/battle-abilities'
     | '/blades'
@@ -618,6 +649,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/accessories'
+    | '/areas'
     | '/armor'
     | '/battle-abilities'
     | '/blades'
@@ -638,6 +670,7 @@ export interface FileRouteTypes {
     | '/material-grid'
     | '/materials'
     | '/accessories/$id'
+    | '/areas/$id'
     | '/armor/$id'
     | '/battle-abilities/$id'
     | '/blades/$id'
@@ -655,6 +688,7 @@ export interface FileRouteTypes {
     | '/titles/$id'
     | '/workshops/$id'
     | '/accessories/'
+    | '/areas/'
     | '/armor/'
     | '/battle-abilities/'
     | '/blades/'
@@ -678,6 +712,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccessoriesRouteRoute: typeof AccessoriesRouteRouteWithChildren
+  AreasRouteRoute: typeof AreasRouteRouteWithChildren
   ArmorRouteRoute: typeof ArmorRouteRouteWithChildren
   BattleAbilitiesRouteRoute: typeof BattleAbilitiesRouteRouteWithChildren
   BladesRouteRoute: typeof BladesRouteRouteWithChildren
@@ -835,6 +870,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ArmorRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/areas': {
+      id: '/areas'
+      path: '/areas'
+      fullPath: '/areas'
+      preLoaderRoute: typeof AreasRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/accessories': {
       id: '/accessories'
       path: '/accessories'
@@ -975,6 +1017,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ArmorIndexRouteImport
       parentRoute: typeof ArmorRouteRoute
     }
+    '/areas/': {
+      id: '/areas/'
+      path: '/'
+      fullPath: '/areas/'
+      preLoaderRoute: typeof AreasIndexRouteImport
+      parentRoute: typeof AreasRouteRoute
+    }
     '/accessories/': {
       id: '/accessories/'
       path: '/'
@@ -1094,6 +1143,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ArmorIdRouteImport
       parentRoute: typeof ArmorRouteRoute
     }
+    '/areas/$id': {
+      id: '/areas/$id'
+      path: '/$id'
+      fullPath: '/areas/$id'
+      preLoaderRoute: typeof AreasIdRouteImport
+      parentRoute: typeof AreasRouteRoute
+    }
     '/accessories/$id': {
       id: '/accessories/$id'
       path: '/$id'
@@ -1116,6 +1172,20 @@ const AccessoriesRouteRouteChildren: AccessoriesRouteRouteChildren = {
 
 const AccessoriesRouteRouteWithChildren =
   AccessoriesRouteRoute._addFileChildren(AccessoriesRouteRouteChildren)
+
+interface AreasRouteRouteChildren {
+  AreasIdRoute: typeof AreasIdRoute
+  AreasIndexRoute: typeof AreasIndexRoute
+}
+
+const AreasRouteRouteChildren: AreasRouteRouteChildren = {
+  AreasIdRoute: AreasIdRoute,
+  AreasIndexRoute: AreasIndexRoute,
+}
+
+const AreasRouteRouteWithChildren = AreasRouteRoute._addFileChildren(
+  AreasRouteRouteChildren,
+)
 
 interface ArmorRouteRouteChildren {
   ArmorIdRoute: typeof ArmorIdRoute
@@ -1354,6 +1424,7 @@ const WorkshopsRouteRouteWithChildren = WorkshopsRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccessoriesRouteRoute: AccessoriesRouteRouteWithChildren,
+  AreasRouteRoute: AreasRouteRouteWithChildren,
   ArmorRouteRoute: ArmorRouteRouteWithChildren,
   BattleAbilitiesRouteRoute: BattleAbilitiesRouteRouteWithChildren,
   BladesRouteRoute: BladesRouteRouteWithChildren,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -83,6 +83,7 @@ const DATABASE_ROUTES = [
   "/keys",
   "/sigils",
   "/workshops",
+  "/areas",
 ]
 
 const NAV_TABS = [

--- a/src/routes/areas/$id.tsx
+++ b/src/routes/areas/$id.tsx
@@ -1,0 +1,260 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
+import { MapPin, X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ItemIcon } from "@/components/item-icon"
+import {
+  gameApi,
+  type Chest,
+  type Grimoire,
+  type Sigil,
+  type Key,
+  type Workshop,
+  type Room,
+} from "@/lib/game-api"
+
+export const Route = createFileRoute("/areas/$id")({
+  component: AreaDetail,
+})
+
+function AreaDetail() {
+  const { id } = Route.useParams()
+
+  const { data: area } = useQuery({
+    queryKey: ["area", id],
+    queryFn: () => gameApi.area(Number(id)),
+  })
+
+  const { data: chests = [] } = useQuery({
+    queryKey: ["chests"],
+    queryFn: gameApi.chests,
+  })
+  const { data: grimoires = [] } = useQuery({
+    queryKey: ["grimoires"],
+    queryFn: gameApi.grimoires,
+  })
+  const { data: sigils = [] } = useQuery({
+    queryKey: ["sigils"],
+    queryFn: gameApi.sigils,
+  })
+  const { data: keys = [] } = useQuery({
+    queryKey: ["keys"],
+    queryFn: gameApi.keys,
+  })
+  const { data: workshops = [] } = useQuery({
+    queryKey: ["workshops"],
+    queryFn: gameApi.workshops,
+  })
+
+  if (!area) return null
+
+  // Build room lookup for items
+  const roomIds = new Set(area.rooms.map((r: Room) => r.id))
+
+  // Group chests by room_id
+  const chestsByRoom = new Map<number, Chest[]>()
+  for (const chest of chests) {
+    if (chest.room_id && roomIds.has(chest.room_id)) {
+      const arr = chestsByRoom.get(chest.room_id) || []
+      arr.push(chest)
+      chestsByRoom.set(chest.room_id, arr)
+    }
+  }
+
+  // Group grimoires by area name match (aggregated endpoint doesn't have room_id)
+  const grimoiresByArea = grimoires.filter((g: Grimoire) =>
+    g.areas.includes(area.name)
+  )
+
+  // Group sigils by room_id
+  const sigilsByRoom = new Map<number, Sigil[]>()
+  for (const sigil of sigils) {
+    if (sigil.room_id && roomIds.has(sigil.room_id)) {
+      const arr = sigilsByRoom.get(sigil.room_id) || []
+      arr.push(sigil)
+      sigilsByRoom.set(sigil.room_id, arr)
+    }
+  }
+
+  // Group keys by room_id
+  const keysByRoom = new Map<number, Key[]>()
+  for (const key of keys) {
+    if (key.room_id && roomIds.has(key.room_id)) {
+      const arr = keysByRoom.get(key.room_id) || []
+      arr.push(key)
+      keysByRoom.set(key.room_id, arr)
+    }
+  }
+
+  // Group workshops by room_id
+  const workshopsByRoom = new Map<number, Workshop[]>()
+  for (const ws of workshops) {
+    if (ws.room_id && roomIds.has(ws.room_id)) {
+      const arr = workshopsByRoom.get(ws.room_id) || []
+      arr.push(ws)
+      workshopsByRoom.set(ws.room_id, arr)
+    }
+  }
+
+  return (
+    <Card className="border-primary/30 mx-auto max-w-4xl">
+      <CardContent className="pt-6">
+        <div className="flex w-full justify-end">
+          <Link
+            to="/areas"
+            className="text-muted-foreground hover:text-foreground -mt-2 -mr-2 p-1"
+          >
+            <X className="size-5" />
+          </Link>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center gap-4">
+            <ItemIcon type="Area" size="lg" className="rounded-lg" />
+            <div>
+              <h2 className="text-3xl font-medium tracking-wide">
+                {area.name}
+              </h2>
+              <p className="text-muted-foreground mt-0.5 text-sm">
+                {area.rooms.length} {area.rooms.length === 1 ? "room" : "rooms"}
+              </p>
+            </div>
+          </div>
+
+          {/* Grimoires found in this area */}
+          {grimoiresByArea.length > 0 && (
+            <div>
+              <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
+                Grimoires in this area
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {grimoiresByArea.map((g: Grimoire) => (
+                  <Link
+                    key={g.id}
+                    to="/grimoires/$id"
+                    params={{ id: String(g.id) }}
+                  >
+                    <Badge
+                      variant="outline"
+                      className="hover:border-primary/40 cursor-pointer transition-colors"
+                    >
+                      <ItemIcon type="Grimoire" size="sm" className="mr-1" />
+                      {g.name} ({g.spell_name})
+                    </Badge>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Rooms */}
+          <div className="space-y-3">
+            <p className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+              Rooms
+            </p>
+            <div className="divide-border divide-y">
+              {area.rooms.map((room: Room) => {
+                const roomChests = chestsByRoom.get(room.id) || []
+                const roomSigils = sigilsByRoom.get(room.id) || []
+                const roomKeys = keysByRoom.get(room.id) || []
+                const roomWorkshops = workshopsByRoom.get(room.id) || []
+                const hasItems =
+                  roomChests.length > 0 ||
+                  roomSigils.length > 0 ||
+                  roomKeys.length > 0 ||
+                  roomWorkshops.length > 0
+
+                return (
+                  <div key={room.id} className="py-3">
+                    <div className="flex items-center gap-2">
+                      <MapPin className="text-muted-foreground size-4 shrink-0" />
+                      <span className="font-medium">{room.name}</span>
+                    </div>
+                    {hasItems && (
+                      <div className="mt-2 ml-6 flex flex-wrap gap-1.5">
+                        {roomChests.map((chest) => (
+                          <Link
+                            key={`chest-${chest.id}`}
+                            to="/chests/$id"
+                            params={{ id: String(chest.id) }}
+                          >
+                            <Badge
+                              variant="secondary"
+                              className="hover:border-primary/40 cursor-pointer text-xs transition-colors"
+                            >
+                              <ItemIcon
+                                type="Chest"
+                                size="sm"
+                                className="mr-1"
+                              />
+                              Chest
+                              {chest.lock_type ? ` (${chest.lock_type})` : ""}
+                            </Badge>
+                          </Link>
+                        ))}
+                        {roomSigils.map((sigil) => (
+                          <Link
+                            key={`sigil-${sigil.id}`}
+                            to="/sigils/$id"
+                            params={{ id: String(sigil.id) }}
+                          >
+                            <Badge
+                              variant="secondary"
+                              className="hover:border-primary/40 cursor-pointer text-xs transition-colors"
+                            >
+                              <ItemIcon
+                                type="Sigil"
+                                size="sm"
+                                className="mr-1"
+                              />
+                              {sigil.name}
+                            </Badge>
+                          </Link>
+                        ))}
+                        {roomKeys.map((key) => (
+                          <Link
+                            key={`key-${key.id}`}
+                            to="/keys/$id"
+                            params={{ id: String(key.id) }}
+                          >
+                            <Badge
+                              variant="secondary"
+                              className="hover:border-primary/40 cursor-pointer text-xs transition-colors"
+                            >
+                              <ItemIcon type="Key" size="sm" className="mr-1" />
+                              {key.name}
+                            </Badge>
+                          </Link>
+                        ))}
+                        {roomWorkshops.map((ws) => (
+                          <Link
+                            key={`ws-${ws.id}`}
+                            to="/workshops/$id"
+                            params={{ id: String(ws.id) }}
+                          >
+                            <Badge
+                              variant="secondary"
+                              className="hover:border-primary/40 cursor-pointer text-xs transition-colors"
+                            >
+                              <ItemIcon
+                                type="Workshop"
+                                size="sm"
+                                className="mr-1"
+                              />
+                              {ws.name}
+                            </Badge>
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/routes/areas/index.tsx
+++ b/src/routes/areas/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/areas/")({
+  component: () => (
+    <div>
+      <h1 className="text-3xl tracking-wide sm:text-4xl">Areas</h1>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Locations throughout Lea Monde — click for rooms and details
+      </p>
+    </div>
+  ),
+})

--- a/src/routes/areas/route.tsx
+++ b/src/routes/areas/route.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { DatabaseSelect } from "@/components/database-select"
+import { AreasPage } from "@/pages/areas/areas-page"
+
+export const Route = createFileRoute("/areas")({
+  component: () => (
+    <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <DatabaseSelect />
+      <Outlet />
+      <AreasPage />
+    </div>
+  ),
+})

--- a/src/routes/chests/$id.tsx
+++ b/src/routes/chests/$id.tsx
@@ -14,6 +14,7 @@ import {
   type Gem,
   type Consumable,
   type Grimoire,
+  type Area,
 } from "@/lib/game-api"
 
 export const Route = createFileRoute("/chests/$id")({
@@ -99,8 +100,16 @@ function ChestDetail() {
     queryKey: ["keys"],
     queryFn: gameApi.keys,
   })
+  const { data: areas = [] } = useQuery<Area[]>({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
 
   if (!chest) return null
+
+  // Find area for cross-linking (normalize "Town Centre" -> "Town Center")
+  const normalizedArea = chest.area.replace("Town Centre", "Town Center")
+  const linkedArea = areas.find((a) => a.name === normalizedArea)
 
   // Build lookup maps by name
   const lookups: Record<string, Map<string, number>> = {
@@ -155,7 +164,17 @@ function ChestDetail() {
                 {chest.room}
               </h2>
               <p className="text-muted-foreground mt-0.5 text-sm">
-                {chest.area}
+                {linkedArea ? (
+                  <Link
+                    to="/areas/$id"
+                    params={{ id: String(linkedArea.id) }}
+                    className="text-primary hover:underline"
+                  >
+                    {chest.area}
+                  </Link>
+                ) : (
+                  chest.area
+                )}
               </p>
               {chest.lock_type && (
                 <div className="mt-2 flex items-center justify-center gap-2 text-sm">

--- a/src/routes/grimoires/$id.tsx
+++ b/src/routes/grimoires/$id.tsx
@@ -4,7 +4,7 @@ import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ItemIcon } from "@/components/item-icon"
-import { gameApi, type Spell } from "@/lib/game-api"
+import { gameApi, type Spell, type Area } from "@/lib/game-api"
 
 export const Route = createFileRoute("/grimoires/$id")({
   component: GrimoireDetail,
@@ -22,12 +22,19 @@ function GrimoireDetail() {
     queryFn: gameApi.spells,
   })
 
+  const { data: areas = [] } = useQuery<Area[]>({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
+
   const item = grimoires.find((g) => g.id === Number(id))
   if (!item) return null
 
+  const areaLookup = new Map(areas.map((a) => [a.name, a]))
+
   const linkedSpell = spells.find((s: Spell) => s.name === item.spell_name)
 
-  const areas = item.areas.split(", ").filter(Boolean)
+  const areaEntries = item.areas.split(", ").filter(Boolean)
   const sources = item.sources.split(", ").filter(Boolean)
   const rates = item.drop_rates.split(", ").filter(Boolean)
 
@@ -75,23 +82,49 @@ function GrimoireDetail() {
                 Sources
               </p>
               <div className="space-y-2">
-                {areas.map((area, i) => (
-                  <div
-                    key={i}
-                    className="bg-muted/50 flex items-center justify-between rounded px-3 py-2 text-sm"
-                  >
-                    <div>
-                      <span>{area}</span>
-                      <span className="text-muted-foreground">
-                        {" "}
-                        — {sources[i] || "Unknown"}
-                      </span>
+                {areaEntries.map((areaEntry, i) => {
+                  // Parse "Area — Room" format
+                  const dashIdx = areaEntry.indexOf(" \u2014 ")
+                  const areaName =
+                    dashIdx >= 0 ? areaEntry.slice(0, dashIdx) : areaEntry
+                  const roomName =
+                    dashIdx >= 0 ? areaEntry.slice(dashIdx + 3) : ""
+                  const matchedArea = areaLookup.get(areaName)
+
+                  return (
+                    <div
+                      key={i}
+                      className="bg-muted/50 flex items-center justify-between rounded px-3 py-2 text-sm"
+                    >
+                      <div>
+                        {matchedArea ? (
+                          <Link
+                            to="/areas/$id"
+                            params={{ id: String(matchedArea.id) }}
+                            className="text-primary hover:underline"
+                          >
+                            {areaName}
+                          </Link>
+                        ) : (
+                          <span>{areaName}</span>
+                        )}
+                        {roomName && (
+                          <span className="text-muted-foreground">
+                            {" "}
+                            &mdash; {roomName}
+                          </span>
+                        )}
+                        <span className="text-muted-foreground">
+                          {" "}
+                          — {sources[i] || "Unknown"}
+                        </span>
+                      </div>
+                      <Badge variant="outline" className="ml-2 shrink-0">
+                        {rates[i] || "Once"}
+                      </Badge>
                     </div>
-                    <Badge variant="outline" className="ml-2 shrink-0">
-                      {rates[i] || "Once"}
-                    </Badge>
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             </div>
           </div>

--- a/src/routes/keys/$id.tsx
+++ b/src/routes/keys/$id.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
-import { gameApi } from "@/lib/game-api"
+import { gameApi, type Area } from "@/lib/game-api"
 
 export const Route = createFileRoute("/keys/$id")({
   component: KeyDetail,
@@ -15,9 +15,15 @@ function KeyDetail() {
     queryKey: ["keys"],
     queryFn: gameApi.keys,
   })
+  const { data: areas = [] } = useQuery<Area[]>({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
 
   const item = keys.find((k) => k.id === Number(id))
   if (!item) return null
+
+  const linkedArea = areas.find((a) => a.name === item.area)
 
   const locations = item.locations_used
     .split(", ")
@@ -50,7 +56,25 @@ function KeyDetail() {
                 <span className="text-muted-foreground font-medium">
                   Found in:
                 </span>{" "}
-                {item.room ? `${item.room} (${item.area})` : item.area}
+                {item.room ? (
+                  <>
+                    {item.room} (
+                    {linkedArea ? (
+                      <Link
+                        to="/areas/$id"
+                        params={{ id: String(linkedArea.id) }}
+                        className="text-primary hover:underline"
+                      >
+                        {item.area}
+                      </Link>
+                    ) : (
+                      item.area
+                    )}
+                    )
+                  </>
+                ) : (
+                  item.area
+                )}
               </p>
               <p>
                 <span className="text-muted-foreground font-medium">

--- a/src/routes/sigils/$id.tsx
+++ b/src/routes/sigils/$id.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
-import { gameApi } from "@/lib/game-api"
+import { gameApi, type Area } from "@/lib/game-api"
 
 export const Route = createFileRoute("/sigils/$id")({
   component: SigilDetail,
@@ -15,9 +15,15 @@ function SigilDetail() {
     queryKey: ["sigils"],
     queryFn: gameApi.sigils,
   })
+  const { data: areas = [] } = useQuery<Area[]>({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
 
   const item = sigils.find((s) => s.id === Number(id))
   if (!item) return null
+
+  const linkedArea = areas.find((a) => a.name === item.area)
 
   return (
     <Card className="border-primary/30 mx-auto max-w-3xl">
@@ -46,7 +52,19 @@ function SigilDetail() {
                 <span className="text-muted-foreground font-medium">
                   Found in:
                 </span>{" "}
-                {item.room} ({item.area})
+                {item.room} (
+                {linkedArea ? (
+                  <Link
+                    to="/areas/$id"
+                    params={{ id: String(linkedArea.id) }}
+                    className="text-primary hover:underline"
+                  >
+                    {item.area}
+                  </Link>
+                ) : (
+                  item.area
+                )}
+                )
               </p>
               <p>
                 <span className="text-muted-foreground font-medium">

--- a/src/routes/workshops/$id.tsx
+++ b/src/routes/workshops/$id.tsx
@@ -4,7 +4,7 @@ import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
 import { MaterialBadge } from "@/components/stat-display"
-import { gameApi } from "@/lib/game-api"
+import { gameApi, type Area } from "@/lib/game-api"
 
 export const Route = createFileRoute("/workshops/$id")({
   component: WorkshopDetail,
@@ -16,9 +16,19 @@ function WorkshopDetail() {
     queryKey: ["workshops"],
     queryFn: gameApi.workshops,
   })
+  const { data: areas = [] } = useQuery<Area[]>({
+    queryKey: ["areas"],
+    queryFn: gameApi.areas,
+  })
 
   const item = workshops.find((w) => w.id === Number(id))
   if (!item) return null
+
+  // Workshop area is "Area: Room" — extract area name for linking
+  const colonIdx = item.area.indexOf(": ")
+  const wsAreaName = colonIdx >= 0 ? item.area.slice(0, colonIdx) : item.area
+  const wsRoomName = colonIdx >= 0 ? item.area.slice(colonIdx + 2) : ""
+  const linkedArea = areas.find((a) => a.name === wsAreaName)
 
   const materials = item.available_materials
     .split(", ")
@@ -50,7 +60,20 @@ function WorkshopDetail() {
               <span className="text-muted-foreground font-medium">
                 Location:
               </span>{" "}
-              {item.area}
+              {linkedArea ? (
+                <>
+                  <Link
+                    to="/areas/$id"
+                    params={{ id: String(linkedArea.id) }}
+                    className="text-primary hover:underline"
+                  >
+                    {wsAreaName}
+                  </Link>
+                  {wsRoomName && `: ${wsRoomName}`}
+                </>
+              ) : (
+                item.area
+              )}
             </p>
             <div>
               <p className="text-muted-foreground mb-1.5 text-sm font-medium">


### PR DESCRIPTION
## Summary
- Add Areas as a new database page listing all 24 game areas with room counts
- Area detail page shows rooms with linked chests, sigils, keys, workshops, and grimoires
- Cross-link area names from chest, sigil, key, grimoire, and workshop detail pages
- Update game-api.ts interfaces for Area/Room types and room_id fields
- Add "Areas" to database navigation dropdown and homepage cards

## Depends on
- API PR: ag-tech-group/vagrant-story-api#41 (merged)

## Test plan
- [ ] Navigate to /areas — see 24 areas with room counts
- [ ] Click an area (e.g., Wine Cellar) — see rooms with linked items
- [ ] From a chest detail page, click the area name — navigates to area page
- [ ] From a sigil detail, key detail, or workshop detail — area name links work
- [ ] From grimoire detail sources — area names in the "Area — Room" entries link to area pages
- [ ] Homepage shows Areas card with count
- [ ] Database dropdown includes "Areas" option