### PR TITLE
fix: crafting scroll, active row highlight, grimoire truncation

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Link } from "@tanstack/react-router"
+import { Link, useLocation } from "@tanstack/react-router"
 import {
   flexRender,
   getFilteredRowModel,
@@ -38,6 +38,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { cn } from "@/lib/utils"
 
 export interface ColumnFilter {
   column: string
@@ -64,6 +65,7 @@ export function DataTable<T>({
   pageSize = 10,
   filters,
 }: DataTableProps<T>) {
+  const location = useLocation()
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState("")
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -184,10 +186,19 @@ export function DataTable<T>({
                 const link = getRowLink?.(row)
 
                 if (link) {
+                  const resolvedPath = Object.entries(link.params).reduce(
+                    (path, [key, value]) => path.replace(`$${key}`, value),
+                    link.to
+                  )
+                  const isActive = location.pathname === resolvedPath
+
                   return (
                     <TableRow
                       key={row.id}
-                      className="hover:bg-muted/50 cursor-pointer"
+                      className={cn(
+                        "hover:bg-muted/50 cursor-pointer",
+                        isActive && "border-l-primary bg-muted/30 border-l-2"
+                      )}
                     >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id} className="p-0">

--- a/src/pages/crafting/crafting-page.tsx
+++ b/src/pages/crafting/crafting-page.tsx
@@ -109,6 +109,7 @@ export function CraftingPage() {
           return next
         },
         replace: true,
+        resetScroll: false,
       }),
     [navigate]
   )

--- a/src/pages/grimoires/grimoires-page.tsx
+++ b/src/pages/grimoires/grimoires-page.tsx
@@ -61,27 +61,53 @@ export function GrimoiresPage() {
       {
         accessorKey: "areas",
         header: "Area",
-        cell: ({ getValue }) => (
-          <span className="text-sm">{getValue<string>()}</span>
-        ),
+        cell: ({ getValue }) => {
+          const v = getValue<string>()
+          const parts = v.split(", ")
+          if (parts.length <= 1) return <span className="text-sm">{v}</span>
+          return (
+            <span className="text-sm">
+              {parts[0]}{" "}
+              <span className="text-muted-foreground text-xs">
+                (+{parts.length - 1})
+              </span>
+            </span>
+          )
+        },
         enableSorting: false,
       },
       {
         accessorKey: "sources",
         header: "Source",
-        cell: ({ getValue }) => (
-          <span className="text-muted-foreground text-sm">
-            {getValue<string>()}
-          </span>
-        ),
+        cell: ({ getValue }) => {
+          const v = getValue<string>()
+          const parts = v.split(", ")
+          if (parts.length <= 1)
+            return <span className="text-muted-foreground text-sm">{v}</span>
+          return (
+            <span className="text-muted-foreground text-sm">
+              {parts[0]} <span className="text-xs">(+{parts.length - 1})</span>
+            </span>
+          )
+        },
         enableSorting: false,
       },
       {
         accessorKey: "drop_rates",
         header: "Rate",
-        cell: ({ getValue }) => (
-          <span className="text-sm">{getValue<string>()}</span>
-        ),
+        cell: ({ getValue }) => {
+          const v = getValue<string>()
+          const parts = v.split(", ")
+          if (parts.length <= 1) return <span className="text-sm">{v}</span>
+          return (
+            <span className="text-sm">
+              {parts[0]}{" "}
+              <span className="text-muted-foreground text-xs">
+                (+{parts.length - 1})
+              </span>
+            </span>
+          )
+        },
         enableSorting: false,
       },
     ],


### PR DESCRIPTION
## Summary
- **Crafting scroll bug:** Added `resetScroll: false` to the crafting page's `navigate()` calls so changing search params (selecting items/materials) no longer snaps the page to the top
- **Active row highlight:** DataTable now detects when a detail route (`$id`) is open and highlights the corresponding table row with a primary-colored left border and subtle background
- **Grimoire truncation:** Long comma-separated values in the grimoires table (areas, sources, drop_rates) now show only the first entry with a `(+N)` indicator for additional entries

## Test plan
- [ ] Go to /crafting, select items in the forward calculator — page should NOT scroll to top
- [ ] Go to /blades/5 (or any detail page) — the matching row in the table below should have a highlighted left border
- [ ] Go to /grimoires — rows with multiple areas/sources/rates should show truncated text with (+N) badge