### PR TITLE
fix: mobile item picker scroll, grip type icons, URL-based inventory routing

### DIFF
--- a/src/components/item-icon.tsx
+++ b/src/components/item-icon.tsx
@@ -35,6 +35,10 @@ const ICON_MAP: Record<string, string> = {
   // Others
   Gem: "Gem",
   Grip: "Grip",
+  Hilt: "Grip",
+  Haft: "Grip",
+  Shaft: "Grip",
+  Bolt: "Grip",
   Consumable: "Consumable",
   Material: "Bronze",
   Spell: "Spell",

--- a/src/components/item-picker.tsx
+++ b/src/components/item-picker.tsx
@@ -15,7 +15,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { cn, useIsMobile } from "@/lib/utils"
 
 export interface PickerItem {
   name: string
@@ -32,6 +38,109 @@ interface ItemPickerProps {
   formatType?: (type: string) => string
 }
 
+function TriggerButton({
+  value,
+  selectedItem,
+  placeholder,
+  formatType,
+  onClear,
+  onClick,
+}: {
+  value: string | null
+  selectedItem: PickerItem | null | undefined
+  placeholder: string
+  formatType?: (type: string) => string
+  onClear: () => void
+  onClick?: () => void
+}) {
+  return (
+    <Button
+      variant="outline"
+      role="combobox"
+      className="h-auto min-h-12 w-full justify-between px-3 py-2"
+      onClick={onClick}
+    >
+      {value ? (
+        <div className="flex flex-1 items-center gap-2">
+          <ItemIcon type={selectedItem?.type} size="sm" />
+          <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">
+            {value}
+          </span>
+          {selectedItem?.type && (
+            <span className="text-muted-foreground shrink-0 text-xs">
+              {formatType ? formatType(selectedItem.type) : selectedItem.type}
+            </span>
+          )}
+        </div>
+      ) : (
+        <span className="text-muted-foreground text-sm">{placeholder}</span>
+      )}
+      <div className="flex items-center gap-1">
+        {value && (
+          <span
+            role="button"
+            tabIndex={0}
+            className="text-muted-foreground hover:text-foreground cursor-pointer"
+            onPointerDown={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onClear()
+            }}
+          >
+            <X className="size-4" />
+          </span>
+        )}
+        <ChevronsUpDown className="text-muted-foreground size-4" />
+      </div>
+    </Button>
+  )
+}
+
+function ItemCommandList({
+  groups,
+  value,
+  onSelect,
+  maxHeight,
+}: {
+  groups: Record<string, PickerItem[]>
+  value: string | null
+  onSelect: (name: string) => void
+  maxHeight?: string
+}) {
+  return (
+    <Command>
+      <CommandInput placeholder="Search items..." />
+      <CommandList className={maxHeight}>
+        <CommandEmpty>No items found.</CommandEmpty>
+        {Object.entries(groups).map(([type, groupItems]) => (
+          <CommandGroup key={type} heading={type}>
+            {groupItems.map((item) => (
+              <CommandItem
+                key={item.name}
+                value={item.name}
+                onSelect={() => onSelect(item.name)}
+              >
+                <ItemIcon type={item.type} size="sm" />
+                <span className="flex-1">{item.name}</span>
+                <Check
+                  className={cn(
+                    "ml-auto size-4",
+                    value === item.name ? "opacity-100" : "opacity-0"
+                  )}
+                />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </Command>
+  )
+}
+
 export function ItemPicker({
   items,
   value,
@@ -41,6 +150,7 @@ export function ItemPicker({
   formatType,
 }: ItemPickerProps) {
   const [open, setOpen] = useState(false)
+  const isMobile = useIsMobile()
   const selectedItem = value ? items.find((i) => i.name === value) : null
 
   // Group items by type, sorted by level within each group
@@ -54,6 +164,52 @@ export function ItemPicker({
     items.sort((a, b) => (a.level ?? 0) - (b.level ?? 0))
   }
 
+  const handleSelect = (name: string) => {
+    onSelect(name === value ? null : name)
+    setOpen(false)
+  }
+
+  const handleClear = () => {
+    onSelect(null)
+    setOpen(false)
+  }
+
+  if (isMobile) {
+    return (
+      <div className="flex flex-col gap-1">
+        {label && (
+          <span className="text-muted-foreground text-xs font-medium">
+            {label}
+          </span>
+        )}
+        <TriggerButton
+          value={value}
+          selectedItem={selectedItem}
+          placeholder={placeholder}
+          formatType={formatType}
+          onClear={handleClear}
+          onClick={() => setOpen(true)}
+        />
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent
+            className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-md"
+            showCloseButton={false}
+          >
+            <DialogHeader className="sr-only">
+              <DialogTitle>{placeholder}</DialogTitle>
+            </DialogHeader>
+            <ItemCommandList
+              groups={groups}
+              value={value}
+              onSelect={handleSelect}
+              maxHeight="max-h-[70vh]"
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-1">
       {label && (
@@ -63,89 +219,25 @@ export function ItemPicker({
       )}
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            className="h-auto min-h-12 w-full justify-between px-3 py-2"
-          >
-            {value ? (
-              <div className="flex flex-1 items-center gap-2">
-                <ItemIcon type={selectedItem?.type} size="sm" />
-                <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">
-                  {value}
-                </span>
-                {selectedItem?.type && (
-                  <span className="text-muted-foreground shrink-0 text-xs">
-                    {formatType
-                      ? formatType(selectedItem.type)
-                      : selectedItem.type}
-                  </span>
-                )}
-              </div>
-            ) : (
-              <span className="text-muted-foreground text-sm">
-                {placeholder}
-              </span>
-            )}
-            <div className="flex items-center gap-1">
-              {value && (
-                <span
-                  role="button"
-                  tabIndex={0}
-                  className="text-muted-foreground hover:text-foreground cursor-pointer"
-                  onPointerDown={(e) => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                  }}
-                  onClick={(e) => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    onSelect(null)
-                    setOpen(false)
-                  }}
-                >
-                  <X className="size-4" />
-                </span>
-              )}
-              <ChevronsUpDown className="text-muted-foreground size-4" />
-            </div>
-          </Button>
+          <TriggerButton
+            value={value}
+            selectedItem={selectedItem}
+            placeholder={placeholder}
+            formatType={formatType}
+            onClear={handleClear}
+          />
         </PopoverTrigger>
         <PopoverContent
           className="w-[var(--radix-popover-trigger-width)] p-0"
           align="start"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
-          <Command>
-            <CommandInput placeholder="Search items..." />
-            <CommandList className="[&]:touch-action-pan-y max-h-[min(300px,60vh)] overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]">
-              <CommandEmpty>No items found.</CommandEmpty>
-              {Object.entries(groups).map(([type, groupItems]) => (
-                <CommandGroup key={type} heading={type}>
-                  {groupItems.map((item) => (
-                    <CommandItem
-                      key={item.name}
-                      value={item.name}
-                      onSelect={() => {
-                        onSelect(item.name === value ? null : item.name)
-                        setOpen(false)
-                      }}
-                    >
-                      <ItemIcon type={item.type} size="sm" />
-                      <span className="flex-1">{item.name}</span>
-                      <Check
-                        className={cn(
-                          "ml-auto size-4",
-                          value === item.name ? "opacity-100" : "opacity-0"
-                        )}
-                      />
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              ))}
-            </CommandList>
-          </Command>
+          <ItemCommandList
+            groups={groups}
+            value={value}
+            onSelect={handleSelect}
+            maxHeight="max-h-[min(300px,60vh)]"
+          />
         </PopoverContent>
       </Popover>
     </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,23 @@
+import { useCallback, useSyncExternalStore } from "react"
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function useIsMobile(breakpoint = 640) {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+      mql.addEventListener("change", callback)
+      return () => mql.removeEventListener("change", callback)
+    },
+    [breakpoint]
+  )
+  const getSnapshot = useCallback(
+    () => window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
+    [breakpoint]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot, () => false)
 }

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link, useParams } from "@tanstack/react-router"
 import { ArrowLeft, Package, Plus, Trash2, X } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -12,7 +13,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
 import { ItemIcon } from "@/components/item-icon"
 import { ItemPicker, type PickerItem } from "@/components/item-picker"
 import { MaterialSelect } from "@/components/material-select"
@@ -40,7 +40,6 @@ import {
   type CreateInventoryItem,
   type EquipSlot,
   type InventoryItem,
-  type InventoryListItem,
 } from "@/lib/inventory-api"
 import { cn } from "@/lib/utils"
 
@@ -53,19 +52,14 @@ interface SlotConfig {
   key: EquipSlot
   label: string
   gridArea: string
-  itemTypes: string[] // armor_type values or "blade" for blades
+  itemTypes: string[]
   isBlade?: boolean
   isShield?: boolean
   isAccessory?: boolean
 }
 
 const EQUIP_SLOTS: SlotConfig[] = [
-  {
-    key: "head",
-    label: "Head",
-    gridArea: "head",
-    itemTypes: ["Helm"],
-  },
+  { key: "head", label: "Head", gridArea: "head", itemTypes: ["Helm"] },
   {
     key: "right_hand",
     label: "R. Hand",
@@ -73,12 +67,7 @@ const EQUIP_SLOTS: SlotConfig[] = [
     itemTypes: ["blade"],
     isBlade: true,
   },
-  {
-    key: "body",
-    label: "Body",
-    gridArea: "body",
-    itemTypes: ["Body"],
-  },
+  { key: "body", label: "Body", gridArea: "body", itemTypes: ["Body"] },
   {
     key: "left_hand",
     label: "L. Hand",
@@ -86,18 +75,8 @@ const EQUIP_SLOTS: SlotConfig[] = [
     itemTypes: ["Shield"],
     isShield: true,
   },
-  {
-    key: "arms",
-    label: "Arms",
-    gridArea: "arms",
-    itemTypes: ["Arm"],
-  },
-  {
-    key: "legs",
-    label: "Legs",
-    gridArea: "legs",
-    itemTypes: ["Leg"],
-  },
+  { key: "arms", label: "Arms", gridArea: "arms", itemTypes: ["Arm"] },
+  { key: "legs", label: "Legs", gridArea: "legs", itemTypes: ["Leg"] },
   {
     key: "accessory",
     label: "Accessory",
@@ -113,11 +92,9 @@ const SHIELD_MATS = ["Wood", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
 
 // ── Main component ──────────────────────────────────────────────────
 
-export function InventoryPage() {
+export function InventoryDetailPage() {
+  const { inventoryId } = useParams({ from: "/inventory/$inventoryId" })
   const auth = useAuth()
-  const [selectedInventoryId, setSelectedInventoryId] = useState<number | null>(
-    null
-  )
 
   if (auth.isLoading) {
     return (
@@ -144,186 +121,10 @@ export function InventoryPage() {
     )
   }
 
-  if (selectedInventoryId != null) {
-    return (
-      <InventoryDetailView
-        inventoryId={selectedInventoryId}
-        onBack={() => setSelectedInventoryId(null)}
-      />
-    )
-  }
-
-  return <InventoryListView onSelect={setSelectedInventoryId} />
+  return <InventoryDetail inventoryId={Number(inventoryId)} />
 }
 
-// ── Inventory List ──────────────────────────────────────────────────
-
-function InventoryListView({ onSelect }: { onSelect: (id: number) => void }) {
-  const queryClient = useQueryClient()
-  const [showCreate, setShowCreate] = useState(false)
-  const [newName, setNewName] = useState("")
-
-  const {
-    data: inventories = [],
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["inventories"],
-    queryFn: inventoryApi.list,
-  })
-
-  const createMutation = useMutation({
-    mutationFn: (name: string) => inventoryApi.create(name),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["inventories"] })
-      setShowCreate(false)
-      setNewName("")
-      toast.success("Inventory created")
-    },
-    onError: (err) => toast.error(String(err)),
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: number) => inventoryApi.delete(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["inventories"] })
-      toast.success("Inventory deleted")
-    },
-    onError: (err) => toast.error(String(err)),
-  })
-
-  if (isLoading) {
-    return (
-      <div className="text-muted-foreground py-10 text-center text-sm">
-        Loading inventories...
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="py-10 text-center text-sm text-red-400">
-        Failed to load inventories. Make sure you are signed in.
-      </div>
-    )
-  }
-
-  return (
-    <div className="mx-auto w-full max-w-2xl space-y-4">
-      <div className="flex items-center justify-between">
-        <p className="text-muted-foreground text-sm">
-          {inventories.length} inventory{inventories.length !== 1 ? "ies" : ""}
-        </p>
-        <Button size="sm" onClick={() => setShowCreate(true)}>
-          <Plus className="size-3.5" />
-          Create Inventory
-        </Button>
-      </div>
-
-      {inventories.length === 0 && (
-        <div className="text-muted-foreground py-10 text-center text-sm">
-          No inventories yet. Create one to start building your loadout.
-        </div>
-      )}
-
-      <div className="space-y-2">
-        {inventories.map((inv) => (
-          <InventoryCard
-            key={inv.id}
-            inventory={inv}
-            onClick={() => onSelect(inv.id)}
-            onDelete={() => deleteMutation.mutate(inv.id)}
-          />
-        ))}
-      </div>
-
-      {/* Create dialog */}
-      <Dialog open={showCreate} onOpenChange={setShowCreate}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Inventory</DialogTitle>
-            <DialogDescription>
-              Give your inventory a name (e.g. "Main Loadout", "Undead
-              Farming").
-            </DialogDescription>
-          </DialogHeader>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              if (newName.trim()) createMutation.mutate(newName.trim())
-            }}
-          >
-            <Input
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              placeholder="Inventory name"
-              maxLength={100}
-              autoFocus
-            />
-            <DialogFooter className="mt-4">
-              <Button
-                type="submit"
-                disabled={!newName.trim() || createMutation.isPending}
-              >
-                {createMutation.isPending ? "Creating..." : "Create"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-    </div>
-  )
-}
-
-function InventoryCard({
-  inventory,
-  onClick,
-  onDelete,
-}: {
-  inventory: InventoryListItem
-  onClick: () => void
-  onDelete: () => void
-}) {
-  return (
-    <Card
-      className="hover:border-foreground/20 cursor-pointer transition-colors"
-      onClick={onClick}
-    >
-      <CardContent className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <ItemIcon type="Chest" size="sm" />
-          <div>
-            <p className="font-medium">{inventory.name}</p>
-            <p className="text-muted-foreground text-xs">
-              Created {new Date(inventory.created_at).toLocaleDateString()}
-            </p>
-          </div>
-        </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-muted-foreground hover:text-red-400"
-          onClick={(e) => {
-            e.stopPropagation()
-            if (confirm("Delete this inventory?")) onDelete()
-          }}
-        >
-          <Trash2 className="size-4" />
-        </Button>
-      </CardContent>
-    </Card>
-  )
-}
-
-// ── Inventory Detail ────────────────────────────────────────────────
-
-function InventoryDetailView({
-  inventoryId,
-  onBack,
-}: {
-  inventoryId: number
-  onBack: () => void
-}) {
+function InventoryDetail({ inventoryId }: { inventoryId: number }) {
   const queryClient = useQueryClient()
   const [editingSlot, setEditingSlot] = useState<SlotConfig | null>(null)
   const [editingBagItem, setEditingBagItem] = useState(false)
@@ -621,7 +422,7 @@ function InventoryDetailView({
           gripPiercing = grip.piercing
         }
 
-        // Grip gems (gem_1, gem_2, gem_3 on the blade item hold the grip's gems)
+        // Grip gems
         for (const gemId of [item.gem_1_id, item.gem_2_id, item.gem_3_id]) {
           if (!gemId) continue
           const gem = gemIdMap.get(gemId)
@@ -653,7 +454,6 @@ function InventoryDetailView({
         const mat = item.material ? materialMap.get(item.material) : null
 
         if (isAccessory) {
-          // Accessories have no material
           totals.str += armorItem.str
           totals.int += armorItem.int
           totals.agi += armorItem.agi
@@ -733,9 +533,11 @@ function InventoryDetailView({
     <div className="mx-auto w-full max-w-4xl space-y-8">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Button variant="ghost" size="sm" onClick={onBack}>
-          <ArrowLeft className="size-4" />
-          Back
+        <Button variant="ghost" size="sm" asChild>
+          <Link to="/inventory">
+            <ArrowLeft className="size-4" />
+            Back
+          </Link>
         </Button>
         <h2 className="text-lg font-medium">{inventory.name}</h2>
       </div>
@@ -911,7 +713,6 @@ function EquipSlotCard({
   onClear?: () => void
 }) {
   if (!item) {
-    // Empty slot
     return (
       <button
         type="button"
@@ -926,7 +727,6 @@ function EquipSlotCard({
     )
   }
 
-  // Filled slot
   return (
     <button
       type="button"
@@ -1138,7 +938,7 @@ function SlotEditorDialog({
   onClose,
   isPending,
 }: {
-  slot: SlotConfig | null // null = bag item
+  slot: SlotConfig | null
   existingItem?: InventoryItem
   blades: Blade[]
   armor: Armor[]
@@ -1226,7 +1026,6 @@ function SlotEditorDialog({
     const items: PickerItem[] = []
 
     if (!slot) {
-      // Bag: show all item types
       for (const b of blades) {
         items.push({
           name: fmt(b.field_name),
@@ -1294,7 +1093,6 @@ function SlotEditorDialog({
         }
       }
     } else {
-      // Armor slot (Helm, Body, Leg, Arm)
       for (const a of armor) {
         if (slot.itemTypes.includes(a.armor_type)) {
           items.push({
@@ -1327,7 +1125,6 @@ function SlotEditorDialog({
       ? armorMap.get(selectedItem)?.armor_type === "Accessory"
       : false
 
-  // Whether this item type needs a material selector
   const needsMaterial = !isAccessory && !isGrip && !isGem && !isConsumable
 
   // Materials
@@ -1397,7 +1194,6 @@ function SlotEditorDialog({
   const handleConfirm = () => {
     if (!selectedItem) return
 
-    // Resolve IDs
     let item_type: string
     let item_id: number
 
@@ -1420,7 +1216,6 @@ function SlotEditorDialog({
 
     const grip = selectedGrip ? gripMap.get(selectedGrip) : null
 
-    // Resolve gem IDs
     const gemIds = selectedGems.map((name) => {
       if (!name) return null
       const gem = gems.find((g) => fmt(g.field_name) === name)
@@ -1441,7 +1236,6 @@ function SlotEditorDialog({
     onSave(data, existingItem?.id)
   }
 
-  // Can confirm?
   const canConfirm = useMemo(() => {
     if (!selectedItem) return false
     if (needsMaterial && availableMaterials.length > 0 && !selectedMaterial)

--- a/src/pages/inventory/inventory-list.tsx
+++ b/src/pages/inventory/inventory-list.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { Plus, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { ItemIcon } from "@/components/item-icon"
+import { useAuth } from "@/lib/auth"
+import { inventoryApi, type InventoryListItem } from "@/lib/inventory-api"
+
+const AUTH_URL = "https://auth.criticalbit.gg"
+const SITE_URL = "https://vagrant-story.criticalbit.gg"
+
+export function InventoryListPage() {
+  const auth = useAuth()
+
+  if (auth.isLoading) {
+    return (
+      <div className="text-muted-foreground py-20 text-center text-sm">
+        Loading...
+      </div>
+    )
+  }
+
+  if (!auth.isAuthenticated) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-20">
+        <p className="text-muted-foreground text-sm">
+          Sign in to manage your inventory
+        </p>
+        <Button asChild>
+          <a
+            href={`${AUTH_URL}/login?redirect=${encodeURIComponent(SITE_URL + "/inventory")}`}
+          >
+            Sign In
+          </a>
+        </Button>
+      </div>
+    )
+  }
+
+  return <InventoryList />
+}
+
+function InventoryList() {
+  const queryClient = useQueryClient()
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState("")
+
+  const {
+    data: inventories = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["inventories"],
+    queryFn: inventoryApi.list,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (name: string) => inventoryApi.create(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["inventories"] })
+      setShowCreate(false)
+      setNewName("")
+      toast.success("Inventory created")
+    },
+    onError: (err) => toast.error(String(err)),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => inventoryApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["inventories"] })
+      toast.success("Inventory deleted")
+    },
+    onError: (err) => toast.error(String(err)),
+  })
+
+  if (isLoading) {
+    return (
+      <div className="text-muted-foreground py-10 text-center text-sm">
+        Loading inventories...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="py-10 text-center text-sm text-red-400">
+        Failed to load inventories. Make sure you are signed in.
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          {inventories.length} inventory{inventories.length !== 1 ? "ies" : ""}
+        </p>
+        <Button size="sm" onClick={() => setShowCreate(true)}>
+          <Plus className="size-3.5" />
+          Create Inventory
+        </Button>
+      </div>
+
+      {inventories.length === 0 && (
+        <div className="text-muted-foreground py-10 text-center text-sm">
+          No inventories yet. Create one to start building your loadout.
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {inventories.map((inv) => (
+          <InventoryCard
+            key={inv.id}
+            inventory={inv}
+            onDelete={() => deleteMutation.mutate(inv.id)}
+          />
+        ))}
+      </div>
+
+      {/* Create dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Inventory</DialogTitle>
+            <DialogDescription>
+              Give your inventory a name (e.g. "Main Loadout", "Undead
+              Farming").
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (newName.trim()) createMutation.mutate(newName.trim())
+            }}
+          >
+            <Input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Inventory name"
+              maxLength={100}
+              autoFocus
+            />
+            <DialogFooter className="mt-4">
+              <Button
+                type="submit"
+                disabled={!newName.trim() || createMutation.isPending}
+              >
+                {createMutation.isPending ? "Creating..." : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function InventoryCard({
+  inventory,
+  onDelete,
+}: {
+  inventory: InventoryListItem
+  onDelete: () => void
+}) {
+  return (
+    <Link
+      to="/inventory/$inventoryId"
+      params={{ inventoryId: String(inventory.id) }}
+    >
+      <Card className="hover:border-foreground/20 cursor-pointer transition-colors">
+        <CardContent className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <ItemIcon type="Chest" size="sm" />
+            <div>
+              <p className="font-medium">{inventory.name}</p>
+              <p className="text-muted-foreground text-xs">
+                Created {new Date(inventory.created_at).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-red-400"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              if (confirm("Delete this inventory?")) onDelete()
+            }}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -59,6 +59,7 @@ import { Route as SpellsIdRouteImport } from './routes/spells/$id'
 import { Route as SigilsIdRouteImport } from './routes/sigils/$id'
 import { Route as RankingsIdRouteImport } from './routes/rankings/$id'
 import { Route as KeysIdRouteImport } from './routes/keys/$id'
+import { Route as InventoryInventoryIdRouteImport } from './routes/inventory/$inventoryId'
 import { Route as GripsIdRouteImport } from './routes/grips/$id'
 import { Route as GrimoiresIdRouteImport } from './routes/grimoires/$id'
 import { Route as GemsIdRouteImport } from './routes/gems/$id'
@@ -322,6 +323,11 @@ const KeysIdRoute = KeysIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => KeysRouteRoute,
 } as any)
+const InventoryInventoryIdRoute = InventoryInventoryIdRouteImport.update({
+  id: '/$inventoryId',
+  path: '/$inventoryId',
+  getParentRoute: () => InventoryRouteRoute,
+} as any)
 const GripsIdRoute = GripsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -419,6 +425,7 @@ export interface FileRoutesByFullPath {
   '/gems/$id': typeof GemsIdRoute
   '/grimoires/$id': typeof GrimoiresIdRoute
   '/grips/$id': typeof GripsIdRoute
+  '/inventory/$inventoryId': typeof InventoryInventoryIdRoute
   '/keys/$id': typeof KeysIdRoute
   '/rankings/$id': typeof RankingsIdRoute
   '/sigils/$id': typeof SigilsIdRoute
@@ -463,6 +470,7 @@ export interface FileRoutesByTo {
   '/gems/$id': typeof GemsIdRoute
   '/grimoires/$id': typeof GrimoiresIdRoute
   '/grips/$id': typeof GripsIdRoute
+  '/inventory/$inventoryId': typeof InventoryInventoryIdRoute
   '/keys/$id': typeof KeysIdRoute
   '/rankings/$id': typeof RankingsIdRoute
   '/sigils/$id': typeof SigilsIdRoute
@@ -528,6 +536,7 @@ export interface FileRoutesById {
   '/gems/$id': typeof GemsIdRoute
   '/grimoires/$id': typeof GrimoiresIdRoute
   '/grips/$id': typeof GripsIdRoute
+  '/inventory/$inventoryId': typeof InventoryInventoryIdRoute
   '/keys/$id': typeof KeysIdRoute
   '/rankings/$id': typeof RankingsIdRoute
   '/sigils/$id': typeof SigilsIdRoute
@@ -594,6 +603,7 @@ export interface FileRouteTypes {
     | '/gems/$id'
     | '/grimoires/$id'
     | '/grips/$id'
+    | '/inventory/$inventoryId'
     | '/keys/$id'
     | '/rankings/$id'
     | '/sigils/$id'
@@ -638,6 +648,7 @@ export interface FileRouteTypes {
     | '/gems/$id'
     | '/grimoires/$id'
     | '/grips/$id'
+    | '/inventory/$inventoryId'
     | '/keys/$id'
     | '/rankings/$id'
     | '/sigils/$id'
@@ -702,6 +713,7 @@ export interface FileRouteTypes {
     | '/gems/$id'
     | '/grimoires/$id'
     | '/grips/$id'
+    | '/inventory/$inventoryId'
     | '/keys/$id'
     | '/rankings/$id'
     | '/sigils/$id'
@@ -1110,6 +1122,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof KeysIdRouteImport
       parentRoute: typeof KeysRouteRoute
     }
+    '/inventory/$inventoryId': {
+      id: '/inventory/$inventoryId'
+      path: '/$inventoryId'
+      fullPath: '/inventory/$inventoryId'
+      preLoaderRoute: typeof InventoryInventoryIdRouteImport
+      parentRoute: typeof InventoryRouteRoute
+    }
     '/grips/$id': {
       id: '/grips/$id'
       path: '/$id'
@@ -1375,10 +1394,12 @@ const GripsRouteRouteWithChildren = GripsRouteRoute._addFileChildren(
 )
 
 interface InventoryRouteRouteChildren {
+  InventoryInventoryIdRoute: typeof InventoryInventoryIdRoute
   InventoryIndexRoute: typeof InventoryIndexRoute
 }
 
 const InventoryRouteRouteChildren: InventoryRouteRouteChildren = {
+  InventoryInventoryIdRoute: InventoryInventoryIdRoute,
   InventoryIndexRoute: InventoryIndexRoute,
 }
 

--- a/src/routes/inventory/$inventoryId.tsx
+++ b/src/routes/inventory/$inventoryId.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { InventoryDetailPage } from "@/pages/inventory/inventory-detail"
+
+export const Route = createFileRoute("/inventory/$inventoryId")({
+  component: InventoryDetailPage,
+})

--- a/src/routes/inventory/index.tsx
+++ b/src/routes/inventory/index.tsx
@@ -1,18 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { InventoryListPage } from "@/pages/inventory/inventory-list"
 
 export const Route = createFileRoute("/inventory/")({
-  component: InventoryIndex,
+  component: InventoryListPage,
 })
-
-function InventoryIndex() {
-  return (
-    <div className="text-center">
-      <h1 className="text-4xl tracking-wide sm:text-5xl lg:text-6xl">
-        Inventory
-      </h1>
-      <p className="text-muted-foreground mt-1 text-sm">
-        Create equipment loadouts and track your gear
-      </p>
-    </div>
-  )
-}

--- a/src/routes/inventory/route.tsx
+++ b/src/routes/inventory/route.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { InventoryPage } from "@/pages/inventory/inventory-page"
 
 export const Route = createFileRoute("/inventory")({
   component: InventoryLayout,
@@ -8,8 +7,15 @@ export const Route = createFileRoute("/inventory")({
 function InventoryLayout() {
   return (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
+      <div className="text-center">
+        <h1 className="text-4xl tracking-wide sm:text-5xl lg:text-6xl">
+          Inventory
+        </h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Create equipment loadouts and track your gear
+        </p>
+      </div>
       <Outlet />
-      <InventoryPage />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Use Dialog instead of Popover for item picker on mobile to fix touch scrolling
- Add Hilt/Haft/Shaft/Bolt icon mappings so grip types show the Grip icon
- Split inventory into `/inventory` (list) and `/inventory/:id` (detail) routes so browser back navigates from detail to list

## Test plan
- [ ] On mobile, open item picker in inventory — verify touch scrolling works in the dropdown
- [ ] Add a grip to the item bag — verify the grip type icon appears
- [ ] Navigate to an inventory detail — verify URL updates to `/inventory/{id}`
- [ ] Press browser back — verify it returns to the inventory list