### PR TITLE
feat: 1H/2H blade badges, block shield slot for 2H weapons

### DIFF
--- a/src/components/item-picker.tsx
+++ b/src/components/item-picker.tsx
@@ -27,6 +27,7 @@ export interface PickerItem {
   name: string
   type: string
   level?: number
+  suffix?: string
 }
 
 interface ItemPickerProps {
@@ -66,6 +67,11 @@ function TriggerButton({
           <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">
             {value}
           </span>
+          {selectedItem?.suffix && (
+            <span className="bg-muted shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold">
+              {selectedItem.suffix}
+            </span>
+          )}
           {selectedItem?.type && (
             <span className="text-muted-foreground shrink-0 text-xs">
               {formatType ? formatType(selectedItem.type) : selectedItem.type}
@@ -126,6 +132,11 @@ function ItemCommandList({
               >
                 <ItemIcon type={item.type} size="sm" />
                 <span className="flex-1">{item.name}</span>
+                {item.suffix && (
+                  <span className="bg-muted shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold">
+                    {item.suffix}
+                  </span>
+                )}
                 <Check
                   className={cn(
                     "ml-auto size-4",

--- a/src/pages/forge/forge-page.tsx
+++ b/src/pages/forge/forge-page.tsx
@@ -333,7 +333,7 @@ export function ForgePage() {
     const items: PickerItem[] = []
     const byType = new Map<
       string,
-      { name: string; type: string; gameId: number }[]
+      { name: string; type: string; gameId: number; suffix?: string }[]
     >()
 
     for (const b of blades) {
@@ -341,7 +341,12 @@ export function ForgePage() {
       if (!byType.has(type)) byType.set(type, [])
       byType
         .get(type)!
-        .push({ name: fmt(b.field_name), type, gameId: b.game_id })
+        .push({
+          name: fmt(b.field_name),
+          type,
+          gameId: b.game_id,
+          suffix: b.hands,
+        })
     }
     for (const a of armor) {
       if (a.armor_type === "Accessory") continue
@@ -359,7 +364,12 @@ export function ForgePage() {
         const item = group[i]
         if (!seen.has(item.name)) {
           seen.add(item.name)
-          items.push({ name: item.name, type: item.type, level: i + 1 })
+          items.push({
+            name: item.name,
+            type: item.type,
+            level: i + 1,
+            suffix: item.suffix,
+          })
         }
       }
     }

--- a/src/pages/forge/forge-page.tsx
+++ b/src/pages/forge/forge-page.tsx
@@ -339,14 +339,12 @@ export function ForgePage() {
     for (const b of blades) {
       const type = b.blade_type
       if (!byType.has(type)) byType.set(type, [])
-      byType
-        .get(type)!
-        .push({
-          name: fmt(b.field_name),
-          type,
-          gameId: b.game_id,
-          suffix: b.hands,
-        })
+      byType.get(type)!.push({
+        name: fmt(b.field_name),
+        type,
+        gameId: b.game_id,
+        suffix: b.hands,
+      })
     }
     for (const a of armor) {
       if (a.armor_type === "Accessory") continue

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -270,6 +270,14 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
     [inventory]
   )
 
+  // Check if equipped blade is 2H (blocks left_hand shield)
+  const equippedBladeIs2H = useMemo(() => {
+    const rhItem = inventory?.items.find((i) => i.equip_slot === "right_hand")
+    if (!rhItem || rhItem.item_type !== "blade") return false
+    const blade = bladeIdMap.get(rhItem.item_id)
+    return blade?.hands === "2H"
+  }, [inventory, bladeIdMap])
+
   // Bag items (unequipped)
   const bagItems = useMemo(
     () => inventory?.items.filter((i) => i.equip_slot == null) ?? [],
@@ -550,6 +558,7 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
           getItemDisplayType={getItemDisplayType}
           onSlotClick={setEditingSlot}
           onClearSlot={(slotItem) => deleteItemMutation.mutate(slotItem.id)}
+          equippedBladeIs2H={equippedBladeIs2H}
         />
       </div>
 
@@ -656,12 +665,14 @@ function EquipmentGrid({
   getItemDisplayType,
   onSlotClick,
   onClearSlot,
+  equippedBladeIs2H,
 }: {
   getSlotItem: (slot: EquipSlot) => InventoryItem | undefined
   getItemDisplayName: (item: InventoryItem) => string
   getItemDisplayType: (item: InventoryItem) => string
   onSlotClick: (slot: SlotConfig) => void
   onClearSlot: (item: InventoryItem) => void
+  equippedBladeIs2H: boolean
 }) {
   return (
     <div
@@ -680,6 +691,7 @@ function EquipmentGrid({
     >
       {EQUIP_SLOTS.map((slot) => {
         const item = getSlotItem(slot.key)
+        const disabled = slot.key === "left_hand" && equippedBladeIs2H
         return (
           <div key={slot.key} style={{ gridArea: slot.gridArea }}>
             <EquipSlotCard
@@ -687,8 +699,9 @@ function EquipmentGrid({
               item={item}
               displayName={item ? getItemDisplayName(item) : undefined}
               displayType={item ? getItemDisplayType(item) : undefined}
-              onClick={() => onSlotClick(slot)}
+              onClick={() => !disabled && onSlotClick(slot)}
               onClear={item ? () => onClearSlot(item) : undefined}
+              disabled={disabled}
             />
           </div>
         )
@@ -704,6 +717,7 @@ function EquipSlotCard({
   displayType,
   onClick,
   onClear,
+  disabled,
 }: {
   slot: SlotConfig
   item?: InventoryItem
@@ -711,18 +725,29 @@ function EquipSlotCard({
   displayType?: string
   onClick: () => void
   onClear?: () => void
+  disabled?: boolean
 }) {
   if (!item) {
     return (
       <button
         type="button"
         onClick={onClick}
-        className="border-border/50 hover:border-foreground/30 hover:bg-muted/30 flex w-full flex-col items-center justify-center gap-1 rounded-lg border border-dashed p-3 transition-colors"
+        disabled={disabled}
+        className={cn(
+          "flex w-full flex-col items-center justify-center gap-1 rounded-lg border border-dashed p-3 transition-colors",
+          disabled
+            ? "border-border/30 cursor-not-allowed opacity-40"
+            : "border-border/50 hover:border-foreground/30 hover:bg-muted/30"
+        )}
       >
         <span className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
           {slot.label}
         </span>
-        <Plus className="text-muted-foreground/50 size-5" />
+        {disabled ? (
+          <span className="text-muted-foreground text-[9px]">2H equipped</span>
+        ) : (
+          <Plus className="text-muted-foreground/50 size-5" />
+        )}
       </button>
     )
   }
@@ -1031,6 +1056,7 @@ function SlotEditorDialog({
           name: fmt(b.field_name),
           type: b.blade_type,
           level: b.game_id,
+          suffix: b.hands,
         })
       }
       for (const a of armor) {
@@ -1070,6 +1096,7 @@ function SlotEditorDialog({
           name: fmt(b.field_name),
           type: b.blade_type,
           level: b.game_id,
+          suffix: b.hands,
         })
       }
     } else if (slot.isShield) {


### PR DESCRIPTION
## Summary
- Blades now show a **1H/2H badge** in item pickers across inventory and forge
- Left hand (shield) slot is **disabled** when a 2H blade is equipped in the right hand
- Disabled slot shows "2H equipped" message with reduced opacity

## Test plan
- [ ] Open inventory, equip a 2H blade (e.g. Great Sword) — verify shield slot is grayed out with "2H equipped"
- [ ] Open inventory, equip a 1H blade (e.g. Dagger) — verify shield slot is clickable
- [ ] Open any blade picker — verify 1H/2H badges appear next to blade names
- [ ] Open forge, select a blade — verify 1H/2H badge appears in the trigger and dropdown