### PR TITLE
fix: item picker not opening on desktop

### DIFF
--- a/src/components/item-picker.tsx
+++ b/src/components/item-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, type Ref } from "react"
 import { Check, ChevronsUpDown, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ItemIcon } from "@/components/item-icon"
@@ -40,26 +40,28 @@ interface ItemPickerProps {
 }
 
 function TriggerButton({
+  ref,
   value,
   selectedItem,
   placeholder,
   formatType,
   onClear,
-  onClick,
+  ...props
 }: {
+  ref?: Ref<HTMLButtonElement>
   value: string | null
   selectedItem: PickerItem | null | undefined
   placeholder: string
   formatType?: (type: string) => string
   onClear: () => void
-  onClick?: () => void
-}) {
+} & Omit<React.ComponentPropsWithoutRef<typeof Button>, "value">) {
   return (
     <Button
+      ref={ref}
       variant="outline"
       role="combobox"
       className="h-auto min-h-12 w-full justify-between px-3 py-2"
-      onClick={onClick}
+      {...props}
     >
       {value ? (
         <div className="flex flex-1 items-center gap-2">


### PR DESCRIPTION
## Summary
- TriggerButton was not forwarding ref and Radix-injected props from PopoverTrigger asChild
- Use React 19 ref-as-prop pattern and spread remaining props onto Button

## Test plan
- [ ] Click item picker on desktop (forge, inventory) — verify dropdown opens
- [ ] Click item picker on mobile — verify dialog still opens