### PR TITLE
fix: increase spacing between inventory list items

### DIFF
--- a/src/pages/inventory/inventory-list.tsx
+++ b/src/pages/inventory/inventory-list.tsx
@@ -120,7 +120,7 @@ function InventoryList() {
         </div>
       )}
 
-      <div className="space-y-2">
+      <div className="space-y-4">
         {inventories.map((inv) => (
           <InventoryCard
             key={inv.id}


### PR DESCRIPTION
## Summary
- Increase gap between inventory cards from `space-y-2` (8px) to `space-y-4` (16px)