### PR TITLE
fix: add clear button to all filter/search inputs

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -20,6 +20,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronsRight,
+  X,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -91,15 +92,29 @@ export function DataTable<T>({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
-        <Input
-          placeholder={searchPlaceholder}
-          value={globalFilter}
-          onChange={(e) => {
-            setGlobalFilter(e.target.value)
-            table.setPageIndex(0)
-          }}
-          className="max-w-sm"
-        />
+        <div className="relative max-w-sm flex-1">
+          <Input
+            placeholder={searchPlaceholder}
+            value={globalFilter}
+            onChange={(e) => {
+              setGlobalFilter(e.target.value)
+              table.setPageIndex(0)
+            }}
+            className="pr-8"
+          />
+          {globalFilter && (
+            <button
+              type="button"
+              onClick={() => {
+                setGlobalFilter("")
+                table.setPageIndex(0)
+              }}
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
         {filters?.map((f) => (
           <Select
             key={f.column}

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -9,6 +9,7 @@ import {
   Plus,
   Search,
   Trash2,
+  X,
 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -644,8 +645,17 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
                 value={bagSearch}
                 onChange={(e) => setBagSearch(e.target.value)}
                 placeholder="Filter items..."
-                className="pl-9"
+                className="pr-8 pl-9"
               />
+              {bagSearch && (
+                <button
+                  type="button"
+                  onClick={() => setBagSearch("")}
+                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+                >
+                  <X className="size-4" />
+                </button>
+              )}
             </div>
             <Button
               variant="outline"

--- a/src/pages/inventory/inventory-list.tsx
+++ b/src/pages/inventory/inventory-list.tsx
@@ -7,6 +7,7 @@ import {
   Plus,
   Search,
   Trash2,
+  X,
 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -153,8 +154,17 @@ function InventoryList() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Filter inventories..."
-              className="pl-9"
+              className="pr-8 pl-9"
             />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+              >
+                <X className="size-4" />
+              </button>
+            )}
           </div>
           <Button
             variant="outline"


### PR DESCRIPTION
## Summary
- Add X clear button to data table global filter, inventory list filter, and inventory bag filter
- Button appears when input has a value, clears on click
- Consistent styling across all filter inputs

## Test plan
- [ ] Type in any database table filter — X appears, click clears
- [ ] Type in inventory list filter — X appears, click clears
- [ ] Type in item bag filter — X appears, click clears