### PR TITLE
fix: reorder equipment grid layout

### DIFF
--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -819,9 +819,9 @@ function EquipmentGrid({
       style={{
         gridTemplateColumns: "1fr 1fr 1fr",
         gridTemplateAreas: `
-          "rhand    head      accessory"
-          "arms     body      lhand"
-          ".        legs      ."
+          ".        head      accessory"
+          "rhand    body      lhand"
+          "arms     legs      ."
         `,
       }}
     >


### PR DESCRIPTION
## Summary
Reorder equipment grid: Head/Accessory on top, R.Hand/Body/L.Hand in middle, Arms/Legs on bottom.

## Test plan
- [ ] Equipment grid renders with correct slot positions