### PR TITLE
feat: crafting optimizer with multi-step path finding

### DIFF
--- a/src/lib/crafting-optimizer.test.ts
+++ b/src/lib/crafting-optimizer.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildRecipeIndex,
+  findCraftingPaths,
+  findReachableItems,
+  type CraftableItem,
+} from "./crafting-optimizer"
+import type { CraftingRecipe, MaterialRecipe } from "./game-api"
+
+// ── Test fixtures ────────────────────────────────────────────────────
+
+const recipes: CraftingRecipe[] = [
+  {
+    id: 1,
+    category: "blade",
+    sub_category: "Axe_Axe",
+    input_1: "Hand Axe",
+    input_2: "Battle Axe",
+    result: "Francisca",
+    tier_change: 1,
+    has_swap: false,
+  },
+  {
+    id: 2,
+    category: "blade",
+    sub_category: "Axe_Axe",
+    input_1: "Francisca",
+    input_2: "Hand Axe",
+    result: "Tabarzin",
+    tier_change: 1,
+    has_swap: false,
+  },
+  {
+    id: 3,
+    category: "blade",
+    sub_category: "Sword_Sword",
+    input_1: "Spatha",
+    input_2: "Firangi",
+    result: "Rhomphaia",
+    tier_change: 1,
+    has_swap: false,
+  },
+  {
+    id: 4,
+    category: "blade",
+    sub_category: "Sword_Dagger",
+    input_1: "Scramasax",
+    input_2: "Spatha",
+    result: "Firangi",
+    tier_change: 0,
+    has_swap: true,
+  },
+]
+
+const materialRecipes: MaterialRecipe[] = [
+  {
+    id: 1,
+    category: "material",
+    sub_category: "Blade_materials",
+    input_1: "Axe / Mace",
+    input_2: "Axe / Mace",
+    material_1: "Iron",
+    material_2: "Iron",
+    result_material: "Iron",
+    tier_change: 0,
+  },
+  {
+    id: 2,
+    category: "material",
+    sub_category: "Blade_materials",
+    input_1: "Axe / Mace",
+    input_2: "Axe / Mace",
+    material_1: "Hagane",
+    material_2: "Iron",
+    result_material: "Hagane",
+    tier_change: 0,
+  },
+  {
+    id: 3,
+    category: "material",
+    sub_category: "Blade_materials",
+    input_1: "Sword",
+    input_2: "Sword",
+    material_1: "Silver",
+    material_2: "Hagane",
+    result_material: "Damascus",
+    tier_change: 1,
+  },
+]
+
+function makeItem(
+  id: number,
+  name: string,
+  equipType: string,
+  material: string,
+  category = "blade"
+): CraftableItem {
+  return {
+    id,
+    name,
+    category,
+    equipType,
+    material,
+    sourceItem: null,
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("buildRecipeIndex", () => {
+  it("indexes recipes by input pair", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const result = index.byInputPair.get("Hand Axe|Battle Axe")
+    expect(result).toHaveLength(1)
+    expect(result![0].result).toBe("Francisca")
+  })
+
+  it("indexes both orderings for non-identical inputs", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const forward = index.byInputPair.get("Hand Axe|Battle Axe")
+    const reverse = index.byInputPair.get("Battle Axe|Hand Axe")
+    expect(forward).toBeDefined()
+    expect(reverse).toBeDefined()
+    expect(forward![0].id).toBe(reverse![0].id)
+  })
+
+  it("indexes recipes by result", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const result = index.byResult.get("Francisca")
+    expect(result).toHaveLength(1)
+    expect(result![0].input_1).toBe("Hand Axe")
+  })
+
+  it("indexes material recipes by key", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const key = "Axe / Mace|Axe / Mace|Iron|Iron"
+    expect(index.materialByKey.get(key)).toBeDefined()
+    expect(index.materialByKey.get(key)!.result_material).toBe("Iron")
+  })
+})
+
+describe("findCraftingPaths (forward search)", () => {
+  it("finds a 1-step path", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Francisca", material: null },
+      items,
+      index
+    )
+
+    expect(paths.length).toBeGreaterThanOrEqual(1)
+    expect(paths[0].steps).toHaveLength(1)
+    expect(paths[0].result.name).toBe("Francisca")
+  })
+
+  it("finds a 2-step path", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+      makeItem(3, "Hand Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Tabarzin", material: null },
+      items,
+      index
+    )
+
+    expect(paths.length).toBeGreaterThanOrEqual(1)
+    expect(paths[0].steps).toHaveLength(2)
+    expect(paths[0].result.name).toBe("Tabarzin")
+  })
+
+  it("filters by target material", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Francisca", material: "Damascus" },
+      items,
+      index
+    )
+
+    // Iron + Iron can't make Damascus, so no paths
+    expect(paths).toHaveLength(0)
+  })
+
+  it("resolves material outcome from material recipes", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Hagane"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Francisca", material: "Hagane" },
+      items,
+      index
+    )
+
+    expect(paths.length).toBeGreaterThanOrEqual(1)
+    expect(paths[0].result.material).toBe("Hagane")
+  })
+
+  it("returns empty array when no path exists", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Francisca", material: null },
+      items,
+      index
+    )
+
+    // Only 1 item, need 2 to craft
+    expect(paths).toHaveLength(0)
+  })
+
+  it("respects excludeItemIds", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Francisca", material: null },
+      items,
+      index,
+      { excludeItemIds: new Set([1]) }
+    )
+
+    expect(paths).toHaveLength(0)
+  })
+
+  it("ranks shorter paths higher", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+      makeItem(3, "Francisca", "Axe / Mace", "Iron"),
+      makeItem(4, "Hand Axe", "Axe / Mace", "Iron"),
+    ]
+
+    // Tabarzin can be reached in 1 step (Francisca + Hand Axe)
+    // or 2 steps (Hand Axe + Battle Axe → Francisca, then Francisca + Hand Axe → Tabarzin)
+    const paths = findCraftingPaths(
+      { name: "Tabarzin", material: null },
+      items,
+      index
+    )
+
+    expect(paths.length).toBeGreaterThanOrEqual(1)
+    // 1-step path should score higher
+    const oneStep = paths.find((p) => p.steps.length === 1)
+    const twoStep = paths.find((p) => p.steps.length === 2)
+    if (oneStep && twoStep) {
+      expect(oneStep.score).toBeGreaterThan(twoStep.score)
+    }
+  })
+})
+
+describe("findReachableItems (reverse search)", () => {
+  it("finds items reachable in 1 step", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const reachable = findReachableItems(items[0], items, index, {
+      maxDepth: 1,
+    })
+
+    expect(reachable.length).toBeGreaterThanOrEqual(1)
+    const names = reachable.map((r) => r.item.name)
+    expect(names).toContain("Francisca")
+  })
+
+  it("finds items reachable in multiple steps", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+      makeItem(3, "Hand Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const reachable = findReachableItems(items[0], items, index, {
+      maxDepth: 2,
+    })
+
+    const names = reachable.map((r) => r.item.name)
+    expect(names).toContain("Francisca")
+    expect(names).toContain("Tabarzin")
+  })
+
+  it("sorts by depth (closest first)", () => {
+    const index = buildRecipeIndex(recipes, materialRecipes)
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+      makeItem(3, "Hand Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const reachable = findReachableItems(items[0], items, index, {
+      maxDepth: 3,
+    })
+
+    for (let i = 1; i < reachable.length; i++) {
+      expect(reachable[i].depth).toBeGreaterThanOrEqual(reachable[i - 1].depth)
+    }
+  })
+})

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -533,6 +533,91 @@ export function findReachableItems(
   return results.sort((a, b) => a.depth - b.depth)
 }
 
+// ── Discover all craftable results from inventory ────────────────────
+
+export interface CraftableResult {
+  result: CraftableItem
+  step: CraftingStep
+  score: number
+}
+
+/**
+ * Find all items craftable from the current inventory in one step.
+ * Returns deduplicated results ranked by material tier and upgrade potential.
+ */
+export function findAllCraftableResults(
+  craftables: CraftableItem[],
+  index: RecipeIndex
+): CraftableResult[] {
+  syntheticIdCounter = -1
+  const results: CraftableResult[] = []
+  const seen = new Set<string>()
+
+  for (let i = 0; i < craftables.length; i++) {
+    for (let j = i + 1; j < craftables.length; j++) {
+      const a = craftables[i]
+      const b = craftables[j]
+      if (a.category !== b.category) continue
+
+      const recipes = index.byInputPair.get(pairKey(a.name, b.name))
+      if (!recipes) continue
+
+      for (const recipe of recipes) {
+        const isForward = recipe.input_1 === a.name
+        const input1 = isForward ? a : b
+        const input2 = isForward ? b : a
+
+        const matRecipe = resolveResultMaterial(
+          index,
+          input1.equipType,
+          input2.equipType,
+          input1.material,
+          input2.material
+        )
+        const resultMaterial = matRecipe?.result_material ?? input1.material
+
+        const resultKey = `${recipe.result}:${resultMaterial}`
+        if (seen.has(resultKey)) continue
+        seen.add(resultKey)
+
+        const resultItem: CraftableItem = {
+          id: syntheticIdCounter--,
+          name: recipe.result,
+          category: recipe.category,
+          equipType: input1.equipType,
+          material: resultMaterial,
+          sourceItem: null,
+        }
+
+        const step: CraftingStep = {
+          input1,
+          input2,
+          result: resultItem,
+          recipe,
+          materialRecipe: matRecipe,
+          swapped: !isForward,
+        }
+
+        // Score: material tier is primary, upgrade recipes get a bonus
+        const matScore = (MATERIAL_TIER[resultMaterial] ?? 0) * 10
+        const upgradeBonus = recipe.tier_change > 0 ? 5 : 0
+        // Penalize consuming high-tier inputs
+        const inputCost =
+          (MATERIAL_TIER[input1.material] ?? 0) +
+          (MATERIAL_TIER[input2.material] ?? 0)
+
+        results.push({
+          result: resultItem,
+          step,
+          score: matScore + upgradeBonus - inputCost,
+        })
+      }
+    }
+  }
+
+  return results.sort((a, b) => b.score - a.score)
+}
+
 // ── Scoring ──────────────────────────────────────────────────────────
 
 function scorePath(

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -56,12 +56,14 @@ export interface CraftingPath {
 export interface OptimizerConfig {
   maxDepth: number
   maxResults: number
+  maxStates: number
   excludeItemIds: Set<number>
 }
 
 const DEFAULT_CONFIG: OptimizerConfig = {
   maxDepth: 4,
   maxResults: 20,
+  maxStates: 5000,
   excludeItemIds: new Set(),
 }
 
@@ -249,7 +251,13 @@ export function findCraftingPaths(
 
   visited.add(stateKey(queue[0].items))
 
-  while (queue.length > 0 && paths.length < cfg.maxResults) {
+  let statesExplored = 0
+  while (
+    queue.length > 0 &&
+    paths.length < cfg.maxResults &&
+    statesExplored < cfg.maxStates
+  ) {
+    statesExplored++
     const state = queue.shift()!
     if (state.depth >= cfg.maxDepth) continue
 
@@ -440,7 +448,9 @@ export function findReachableItems(
     },
   ]
 
-  while (queue.length > 0) {
+  let statesExplored = 0
+  while (queue.length > 0 && statesExplored < cfg.maxStates) {
+    statesExplored++
     const state = queue.shift()!
     if (state.depth >= cfg.maxDepth) continue
 

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -243,9 +243,10 @@ export function findCraftingPaths(
   const visited = new Set<string>()
 
   function stateKey(items: CraftableItem[]): string {
+    // Use IDs for fast comparison — synthetic items have unique negative IDs
     return items
-      .map((i) => `${i.name}:${i.material}`)
-      .sort()
+      .map((i) => i.id)
+      .sort((a, b) => a - b)
       .join(",")
   }
 

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -535,6 +535,14 @@ export function findReachableItems(
 
 // ── Discover all craftable results from inventory ────────────────────
 
+export interface StatComparison {
+  str: number
+  int: number
+  agi: number
+  /** Sum of all stat diffs (positive = overall improvement) */
+  total: number
+}
+
 export interface CraftableResult {
   result: CraftableItem
   step: CraftingStep
@@ -543,6 +551,8 @@ export interface CraftableResult {
   steps: number
   score: number
   materialUpgrade: boolean
+  /** Stat diff vs best input (positive = improvement) */
+  statDiff: StatComparison | null
 }
 
 /**
@@ -627,6 +637,7 @@ export function findAllCraftableResults(
           steps: 1,
           score: matScore + upgradeBonus - inputCost,
           materialUpgrade,
+          statDiff: null,
         })
       }
     }

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -538,7 +538,9 @@ export function findReachableItems(
 export interface CraftableResult {
   result: CraftableItem
   step: CraftingStep
+  steps: number
   score: number
+  materialUpgrade: boolean
 }
 
 /**
@@ -598,10 +600,20 @@ export function findAllCraftableResults(
           swapped: !isForward,
         }
 
-        // Score: material tier is primary, upgrade recipes get a bonus
-        const matScore = (MATERIAL_TIER[resultMaterial] ?? 0) * 10
-        const upgradeBonus = recipe.tier_change > 0 ? 5 : 0
-        // Penalize consuming high-tier inputs
+        const resultMatTier = MATERIAL_TIER[resultMaterial] ?? 0
+        const bestInputMatTier = Math.max(
+          MATERIAL_TIER[input1.material] ?? 0,
+          MATERIAL_TIER[input2.material] ?? 0
+        )
+        const materialUpgrade = resultMatTier > bestInputMatTier
+
+        // Score: material tier first, upgrade bonus, penalize consuming high-tier
+        const matScore = resultMatTier * 10
+        const upgradeBonus = materialUpgrade
+          ? 15
+          : recipe.tier_change > 0
+            ? 5
+            : 0
         const inputCost =
           (MATERIAL_TIER[input1.material] ?? 0) +
           (MATERIAL_TIER[input2.material] ?? 0)
@@ -609,7 +621,9 @@ export function findAllCraftableResults(
         results.push({
           result: resultItem,
           step,
+          steps: 1,
           score: matScore + upgradeBonus - inputCost,
+          materialUpgrade,
         })
       }
     }

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -69,7 +69,7 @@ const DEFAULT_CONFIG: OptimizerConfig = {
 
 // ── Material tier for scoring ────────────────────────────────────────
 
-const MATERIAL_TIER: Record<string, number> = {
+export const MATERIAL_TIER: Record<string, number> = {
   Wood: 0,
   Leather: 1,
   Bronze: 2,

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -1,0 +1,551 @@
+/**
+ * Crafting Optimizer Algorithm
+ *
+ * Given a player's inventory, finds optimal multi-step crafting paths
+ * to reach a target item+material. Pure functions, no React dependencies.
+ *
+ * Crafting is two-stage:
+ * 1. Item recipe: input_1 + input_2 → result_item (from CraftingRecipe)
+ * 2. Material recipe: type_1(mat_A) + type_2(mat_B) → result_material (from MaterialRecipe)
+ *
+ * Both inputs are destroyed; one new item is created with no history.
+ */
+
+import type {
+  Armor,
+  Blade,
+  CraftingRecipe,
+  MaterialRecipe,
+} from "@/lib/game-api"
+import type { InventoryItem } from "@/lib/inventory-api"
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** A single item in the optimizer's working set */
+export interface CraftableItem {
+  /** Inventory item ID (negative for synthesized items not yet in inventory) */
+  id: number
+  /** Display name (e.g. "Hand Axe") */
+  name: string
+  /** Category: "blade", "armor", "shield" */
+  category: string
+  /** Equipment sub-type for material recipes (e.g. "Dagger", "Helm", "Shield") */
+  equipType: string
+  /** Material name (e.g. "Damascus") */
+  material: string
+  /** Original inventory item reference, null for synthesized */
+  sourceItem: InventoryItem | null
+}
+
+export interface CraftingStep {
+  input1: CraftableItem
+  input2: CraftableItem
+  result: CraftableItem
+  recipe: CraftingRecipe
+  materialRecipe: MaterialRecipe | null
+  swapped: boolean
+}
+
+export interface CraftingPath {
+  steps: CraftingStep[]
+  result: CraftableItem
+  consumedItems: CraftableItem[]
+  score: number
+}
+
+export interface OptimizerConfig {
+  maxDepth: number
+  maxResults: number
+  excludeItemIds: Set<number>
+}
+
+const DEFAULT_CONFIG: OptimizerConfig = {
+  maxDepth: 4,
+  maxResults: 20,
+  excludeItemIds: new Set(),
+}
+
+// ── Material tier for scoring ────────────────────────────────────────
+
+const MATERIAL_TIER: Record<string, number> = {
+  Wood: 0,
+  Leather: 1,
+  Bronze: 2,
+  Iron: 3,
+  Hagane: 4,
+  Silver: 5,
+  Damascus: 6,
+}
+
+// ── Index builders ───────────────────────────────────────────────────
+
+export interface RecipeIndex {
+  /** Map "input1_name|input2_name" → CraftingRecipe[] */
+  byInputPair: Map<string, CraftingRecipe[]>
+  /** Map result_name → CraftingRecipe[] */
+  byResult: Map<string, CraftingRecipe[]>
+  /** Map "type1|type2|mat1|mat2" → MaterialRecipe */
+  materialByKey: Map<string, MaterialRecipe>
+}
+
+function pairKey(a: string, b: string): string {
+  return `${a}|${b}`
+}
+
+function materialKey(
+  type1: string,
+  type2: string,
+  mat1: string,
+  mat2: string
+): string {
+  return `${type1}|${type2}|${mat1}|${mat2}`
+}
+
+export function buildRecipeIndex(
+  recipes: CraftingRecipe[],
+  materialRecipes: MaterialRecipe[]
+): RecipeIndex {
+  const byInputPair = new Map<string, CraftingRecipe[]>()
+  const byResult = new Map<string, CraftingRecipe[]>()
+  const materialByKey = new Map<string, MaterialRecipe>()
+
+  for (const r of recipes) {
+    // Index by input pair (both orderings for swap recipes)
+    const key1 = pairKey(r.input_1, r.input_2)
+    const list1 = byInputPair.get(key1) ?? []
+    list1.push(r)
+    byInputPair.set(key1, list1)
+
+    if (r.input_1 !== r.input_2) {
+      const key2 = pairKey(r.input_2, r.input_1)
+      const list2 = byInputPair.get(key2) ?? []
+      list2.push(r)
+      byInputPair.set(key2, list2)
+    }
+
+    // Index by result
+    const rList = byResult.get(r.result) ?? []
+    rList.push(r)
+    byResult.set(r.result, rList)
+  }
+
+  for (const m of materialRecipes) {
+    materialByKey.set(
+      materialKey(m.input_1, m.input_2, m.material_1, m.material_2),
+      m
+    )
+  }
+
+  return { byInputPair, byResult, materialByKey }
+}
+
+// ── Resolve material outcome ─────────────────────────────────────────
+
+function resolveResultMaterial(
+  index: RecipeIndex,
+  type1: string,
+  type2: string,
+  mat1: string,
+  mat2: string
+): MaterialRecipe | null {
+  // Try exact match
+  const exact = index.materialByKey.get(materialKey(type1, type2, mat1, mat2))
+  if (exact) return exact
+
+  // Try swapped types
+  const swapped = index.materialByKey.get(materialKey(type2, type1, mat2, mat1))
+  if (swapped) return swapped
+
+  // Try same types swapped materials
+  const matSwap = index.materialByKey.get(materialKey(type1, type2, mat2, mat1))
+  if (matSwap) return matSwap
+
+  return null
+}
+
+// ── Convert inventory items to craftable items ───────────────────────
+
+export function inventoryToCraftables(
+  items: InventoryItem[],
+  blades: Blade[],
+  armor: Armor[]
+): CraftableItem[] {
+  const bladeById = new Map(blades.map((b) => [b.id, b]))
+  const armorById = new Map(armor.map((a) => [a.id, a]))
+
+  const result: CraftableItem[] = []
+
+  for (const item of items) {
+    if (item.item_type === "blade") {
+      const blade = bladeById.get(item.item_id)
+      if (!blade) continue
+      result.push({
+        id: item.id,
+        name: blade.name,
+        category: "blade",
+        equipType: blade.blade_type,
+        material: item.material ?? "Iron",
+        sourceItem: item,
+      })
+    } else if (item.item_type === "armor") {
+      const a = armorById.get(item.item_id)
+      if (!a) continue
+      const cat = a.armor_type === "Shield" ? "shield" : "armor"
+      result.push({
+        id: item.id,
+        name: a.name,
+        category: cat,
+        equipType: a.armor_type,
+        material: item.material ?? "Iron",
+        sourceItem: item,
+      })
+    }
+    // Skip grips, gems, consumables — they can't be crafted
+  }
+
+  return result
+}
+
+// ── Forward search: find paths to a target ───────────────────────────
+
+let syntheticIdCounter = -1
+
+export function findCraftingPaths(
+  target: { name: string; material: string | null },
+  craftables: CraftableItem[],
+  index: RecipeIndex,
+  config: Partial<OptimizerConfig> = {}
+): CraftingPath[] {
+  const cfg = { ...DEFAULT_CONFIG, ...config }
+  syntheticIdCounter = -1
+
+  const paths: CraftingPath[] = []
+
+  interface SearchState {
+    items: CraftableItem[]
+    steps: CraftingStep[]
+    consumed: CraftableItem[]
+    depth: number
+  }
+
+  const queue: SearchState[] = [
+    {
+      items: craftables.filter((i) => !cfg.excludeItemIds.has(i.id)),
+      steps: [],
+      consumed: [],
+      depth: 0,
+    },
+  ]
+
+  // Dedup by sorting item names+materials to avoid exploring same state
+  const visited = new Set<string>()
+
+  function stateKey(items: CraftableItem[]): string {
+    return items
+      .map((i) => `${i.name}:${i.material}`)
+      .sort()
+      .join(",")
+  }
+
+  visited.add(stateKey(queue[0].items))
+
+  while (queue.length > 0 && paths.length < cfg.maxResults) {
+    const state = queue.shift()!
+    if (state.depth >= cfg.maxDepth) continue
+
+    // Group items by category for efficient pairing
+    const byCategory = new Map<string, CraftableItem[]>()
+    for (const item of state.items) {
+      const list = byCategory.get(item.category) ?? []
+      list.push(item)
+      byCategory.set(item.category, list)
+    }
+
+    // Try all pairs within each category
+    for (const [, catItems] of byCategory) {
+      for (let i = 0; i < catItems.length; i++) {
+        for (let j = i + 1; j < catItems.length; j++) {
+          const a = catItems[i]
+          const b = catItems[j]
+
+          // Look up recipes for this pair
+          const recipes = index.byInputPair.get(pairKey(a.name, b.name))
+          if (!recipes) continue
+
+          for (const recipe of recipes) {
+            // Determine which item is input_1 and which is input_2
+            const isForward = recipe.input_1 === a.name
+            const input1 = isForward ? a : b
+            const input2 = isForward ? b : a
+
+            // Resolve material outcome
+            const matRecipe = resolveResultMaterial(
+              index,
+              input1.equipType,
+              input2.equipType,
+              input1.material,
+              input2.material
+            )
+
+            const resultMaterial = matRecipe?.result_material ?? input1.material
+
+            // Create result item
+            const resultItem: CraftableItem = {
+              id: syntheticIdCounter--,
+              name: recipe.result,
+              category: recipe.category,
+              equipType: input1.equipType, // Result inherits type from input (approximation)
+              material: resultMaterial,
+              sourceItem: null,
+            }
+
+            const step: CraftingStep = {
+              input1,
+              input2,
+              result: resultItem,
+              recipe,
+              materialRecipe: matRecipe,
+              swapped: !isForward,
+            }
+
+            const newSteps = [...state.steps, step]
+            const newConsumed = [...state.consumed, input1, input2]
+
+            // Check if we reached the target
+            const nameMatch = resultItem.name === target.name
+            const materialMatch =
+              !target.material || resultItem.material === target.material
+
+            if (nameMatch && materialMatch) {
+              paths.push({
+                steps: newSteps,
+                result: resultItem,
+                consumedItems: newConsumed,
+                score: scorePath(newSteps, newConsumed, resultItem),
+              })
+              continue
+            }
+
+            // Continue searching if depth allows
+            if (state.depth + 1 < cfg.maxDepth) {
+              // Build new item set: remove consumed, add result
+              const newItems = state.items.filter(
+                (it) => it.id !== input1.id && it.id !== input2.id
+              )
+              newItems.push(resultItem)
+
+              const key = stateKey(newItems)
+              if (!visited.has(key)) {
+                visited.add(key)
+                queue.push({
+                  items: newItems,
+                  steps: newSteps,
+                  consumed: newConsumed,
+                  depth: state.depth + 1,
+                })
+              }
+            }
+
+            // Also try swap if recipe supports it
+            if (recipe.has_swap && recipe.input_1 !== recipe.input_2) {
+              const swapMatRecipe = resolveResultMaterial(
+                index,
+                input2.equipType,
+                input1.equipType,
+                input2.material,
+                input1.material
+              )
+              const swapMaterial =
+                swapMatRecipe?.result_material ?? input2.material
+
+              if (swapMaterial !== resultMaterial) {
+                const swapResult: CraftableItem = {
+                  id: syntheticIdCounter--,
+                  name: recipe.result,
+                  category: recipe.category,
+                  equipType: input2.equipType,
+                  material: swapMaterial,
+                  sourceItem: null,
+                }
+
+                const swapStep: CraftingStep = {
+                  input1: input2,
+                  input2: input1,
+                  result: swapResult,
+                  recipe,
+                  materialRecipe: swapMatRecipe,
+                  swapped: true,
+                }
+
+                const swapSteps = [...state.steps, swapStep]
+                const swapConsumed = [...state.consumed, input2, input1]
+
+                const swapNameMatch = swapResult.name === target.name
+                const swapMatMatch =
+                  !target.material || swapResult.material === target.material
+
+                if (swapNameMatch && swapMatMatch) {
+                  paths.push({
+                    steps: swapSteps,
+                    result: swapResult,
+                    consumedItems: swapConsumed,
+                    score: scorePath(swapSteps, swapConsumed, swapResult),
+                  })
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Sort by score descending (higher = better)
+  return paths.sort((a, b) => b.score - a.score)
+}
+
+// ── Reverse search: what can I make from this item? ──────────────────
+
+export interface ReachableItem {
+  item: CraftableItem
+  path: CraftingStep[]
+  depth: number
+}
+
+export function findReachableItems(
+  sourceItem: CraftableItem,
+  craftables: CraftableItem[],
+  index: RecipeIndex,
+  config: Partial<OptimizerConfig> = {}
+): ReachableItem[] {
+  const cfg = { ...DEFAULT_CONFIG, ...config }
+  syntheticIdCounter = -1
+
+  const results: ReachableItem[] = []
+  const seen = new Set<string>()
+
+  interface SearchState {
+    currentItem: CraftableItem
+    items: CraftableItem[]
+    path: CraftingStep[]
+    depth: number
+  }
+
+  const queue: SearchState[] = [
+    {
+      currentItem: sourceItem,
+      items: craftables.filter((i) => !cfg.excludeItemIds.has(i.id)),
+      path: [],
+      depth: 0,
+    },
+  ]
+
+  while (queue.length > 0) {
+    const state = queue.shift()!
+    if (state.depth >= cfg.maxDepth) continue
+
+    const { currentItem, items } = state
+
+    // Find all same-category items we can pair with
+    const partners = items.filter(
+      (i) => i.category === currentItem.category && i.id !== currentItem.id
+    )
+
+    for (const partner of partners) {
+      const recipes = index.byInputPair.get(
+        pairKey(currentItem.name, partner.name)
+      )
+      if (!recipes) continue
+
+      for (const recipe of recipes) {
+        const isForward = recipe.input_1 === currentItem.name
+        const input1 = isForward ? currentItem : partner
+        const input2 = isForward ? partner : currentItem
+
+        const matRecipe = resolveResultMaterial(
+          index,
+          input1.equipType,
+          input2.equipType,
+          input1.material,
+          input2.material
+        )
+        const resultMaterial = matRecipe?.result_material ?? input1.material
+
+        const resultKey = `${recipe.result}:${resultMaterial}`
+        if (seen.has(resultKey)) continue
+        seen.add(resultKey)
+
+        const resultItem: CraftableItem = {
+          id: syntheticIdCounter--,
+          name: recipe.result,
+          category: recipe.category,
+          equipType: input1.equipType,
+          material: resultMaterial,
+          sourceItem: null,
+        }
+
+        const step: CraftingStep = {
+          input1,
+          input2,
+          result: resultItem,
+          recipe,
+          materialRecipe: matRecipe,
+          swapped: !isForward,
+        }
+
+        const newPath = [...state.path, step]
+
+        results.push({
+          item: resultItem,
+          path: newPath,
+          depth: state.depth + 1,
+        })
+
+        // Continue searching from this result
+        if (state.depth + 1 < cfg.maxDepth) {
+          const newItems = items.filter(
+            (it) => it.id !== input1.id && it.id !== input2.id
+          )
+          newItems.push(resultItem)
+
+          queue.push({
+            currentItem: resultItem,
+            items: newItems,
+            path: newPath,
+            depth: state.depth + 1,
+          })
+        }
+      }
+    }
+  }
+
+  return results.sort((a, b) => a.depth - b.depth)
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────
+
+function scorePath(
+  steps: CraftingStep[],
+  consumed: CraftableItem[],
+  result: CraftableItem
+): number {
+  let score = 0
+
+  // Fewer steps is much better (10 points per step saved vs max)
+  score += (5 - steps.length) * 10
+
+  // Higher material tier on result is better
+  score += (MATERIAL_TIER[result.material] ?? 0) * 5
+
+  // Prefer consuming lower-tier materials
+  for (const item of consumed) {
+    score -= (MATERIAL_TIER[item.material] ?? 0) * 2
+  }
+
+  // Bonus for upgrade tier changes
+  for (const step of steps) {
+    score += step.recipe.tier_change * 3
+  }
+
+  return score
+}

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -538,6 +538,8 @@ export function findReachableItems(
 export interface CraftableResult {
   result: CraftableItem
   step: CraftingStep
+  /** Full path for multi-step results */
+  path: CraftingStep[]
   steps: number
   score: number
   materialUpgrade: boolean
@@ -621,6 +623,7 @@ export function findAllCraftableResults(
         results.push({
           result: resultItem,
           step,
+          path: [step],
           steps: 1,
           score: matScore + upgradeBonus - inputCost,
           materialUpgrade,

--- a/src/lib/crafting-worker.ts
+++ b/src/lib/crafting-worker.ts
@@ -1,0 +1,73 @@
+/**
+ * Web Worker for crafting optimizer searches.
+ * Runs BFS off the main thread to prevent UI freezing.
+ */
+
+import {
+  buildRecipeIndex,
+  findCraftingPaths,
+  findReachableItems,
+  type CraftableItem,
+  type CraftingPath,
+  type OptimizerConfig,
+  type ReachableItem,
+} from "./crafting-optimizer"
+import type { CraftingRecipe, MaterialRecipe } from "./game-api"
+
+// ── Message types ────────────────────────────────────────────────────
+
+export interface WorkerRequest {
+  type: "forward" | "reverse"
+  craftingRecipes: CraftingRecipe[]
+  materialRecipes: MaterialRecipe[]
+  craftables: CraftableItem[]
+  // Forward-specific
+  targetName?: string
+  targetMaterial?: string | null
+  // Reverse-specific
+  sourceItem?: CraftableItem
+  // Config
+  config?: Partial<OptimizerConfig>
+}
+
+export interface WorkerResponse {
+  type: "forward" | "reverse"
+  forwardPaths?: CraftingPath[]
+  reverseResults?: ReachableItem[]
+  elapsed: number
+}
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const req = event.data
+  const start = performance.now()
+
+  const index = buildRecipeIndex(req.craftingRecipes, req.materialRecipes)
+
+  if (req.type === "forward" && req.targetName) {
+    const paths = findCraftingPaths(
+      { name: req.targetName, material: req.targetMaterial ?? null },
+      req.craftables,
+      index,
+      { maxDepth: 3, maxResults: 20, maxStates: 10000, ...req.config }
+    )
+    const response: WorkerResponse = {
+      type: "forward",
+      forwardPaths: paths,
+      elapsed: performance.now() - start,
+    }
+    self.postMessage(response)
+  } else if (req.type === "reverse" && req.sourceItem) {
+    const results = findReachableItems(req.sourceItem, req.craftables, index, {
+      maxDepth: 2,
+      maxResults: 50,
+      maxStates: 10000,
+      ...req.config,
+    })
+    const response: WorkerResponse = {
+      type: "reverse",
+      reverseResults: results,
+      elapsed: performance.now() - start,
+    }
+    self.postMessage(response)
+  }
+}

--- a/src/lib/crafting-worker.ts
+++ b/src/lib/crafting-worker.ts
@@ -13,8 +13,15 @@ import {
   type CraftableResult,
   type CraftingPath,
   type OptimizerConfig,
+  type StatComparison,
 } from "./crafting-optimizer"
-import type { CraftingRecipe, MaterialRecipe } from "./game-api"
+import type {
+  Armor,
+  Blade,
+  CraftingRecipe,
+  Material,
+  MaterialRecipe,
+} from "./game-api"
 
 // ── Message types ────────────────────────────────────────────────────
 
@@ -23,6 +30,10 @@ export interface WorkerRequest {
   craftingRecipes: CraftingRecipe[]
   materialRecipes: MaterialRecipe[]
   craftables: CraftableItem[]
+  // Game data for stat computation
+  blades?: Blade[]
+  armor?: Armor[]
+  materials?: Material[]
   // Discover-specific
   maxDepth?: number
   // Reverse-specific (find path to target)
@@ -39,11 +50,121 @@ export interface WorkerResponse {
   elapsed: number
 }
 
+// ── Stat computation helpers ─────────────────────────────────────────
+
+function getItemBaseStats(
+  name: string,
+  category: string,
+  bladeMap: Map<string, Blade>,
+  armorMap: Map<string, Armor>
+): { str: number; int: number; agi: number } | null {
+  if (category === "blade") {
+    const b = bladeMap.get(name)
+    return b ? { str: b.str, int: b.int, agi: b.agi } : null
+  }
+  const a = armorMap.get(name)
+  return a ? { str: a.str, int: a.int, agi: a.agi } : null
+}
+
+function getMaterialStats(
+  materialName: string,
+  category: string,
+  matMap: Map<string, Material>
+): { str: number; int: number; agi: number } {
+  const mat = matMap.get(materialName)
+  if (!mat) return { str: 0, int: 0, agi: 0 }
+  if (category === "blade")
+    return { str: mat.blade_str, int: mat.blade_int, agi: mat.blade_agi }
+  if (category === "shield")
+    return { str: mat.shield_str, int: mat.shield_int, agi: mat.shield_agi }
+  return { str: mat.armor_str, int: mat.armor_int, agi: mat.armor_agi }
+}
+
+function computeEffective(
+  name: string,
+  material: string,
+  category: string,
+  bladeMap: Map<string, Blade>,
+  armorMap: Map<string, Armor>,
+  matMap: Map<string, Material>
+): { str: number; int: number; agi: number } | null {
+  const base = getItemBaseStats(name, category, bladeMap, armorMap)
+  if (!base) return null
+  const matStats = getMaterialStats(material, category, matMap)
+  return {
+    str: base.str + matStats.str,
+    int: base.int + matStats.int,
+    agi: base.agi + matStats.agi,
+  }
+}
+
+function computeStatDiff(
+  result: CraftableResult,
+  bladeMap: Map<string, Blade>,
+  armorMap: Map<string, Armor>,
+  matMap: Map<string, Material>
+): StatComparison | null {
+  const cat = result.result.category
+  const resultStats = computeEffective(
+    result.result.name,
+    result.result.material,
+    cat,
+    bladeMap,
+    armorMap,
+    matMap
+  )
+  if (!resultStats) return null
+
+  // Compare against the best input
+  const input1Stats = computeEffective(
+    result.step.input1.name,
+    result.step.input1.material,
+    cat,
+    bladeMap,
+    armorMap,
+    matMap
+  )
+  const input2Stats = computeEffective(
+    result.step.input2.name,
+    result.step.input2.material,
+    cat,
+    bladeMap,
+    armorMap,
+    matMap
+  )
+
+  // Best input = higher total STR+INT+AGI
+  const bestInput = [input1Stats, input2Stats]
+    .filter(Boolean)
+    .sort((a, b) => b!.str + b!.int + b!.agi - (a!.str + a!.int + a!.agi))[0]
+
+  if (!bestInput) return null
+
+  const diff: StatComparison = {
+    str: resultStats.str - bestInput.str,
+    int: resultStats.int - bestInput.int,
+    agi: resultStats.agi - bestInput.agi,
+    total: 0,
+  }
+  diff.total = diff.str + diff.int + diff.agi
+  return diff
+}
+
+// ── Worker message handler ───────────────────────────────────────────
+
 self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   const req = event.data
   const start = performance.now()
 
   const index = buildRecipeIndex(req.craftingRecipes, req.materialRecipes)
+
+  // Build lookup maps for stat computation
+  const bladeMap = new Map<string, Blade>()
+  for (const b of req.blades ?? []) bladeMap.set(b.name, b)
+  const armorMap = new Map<string, Armor>()
+  for (const a of req.armor ?? []) armorMap.set(a.name, a)
+  const matMap = new Map<string, Material>()
+  for (const m of req.materials ?? []) matMap.set(m.name, m)
 
   if (req.type === "discover") {
     const depth = req.maxDepth ?? 1
@@ -52,7 +173,6 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
     if (depth <= 1) {
       results = findAllCraftableResults(req.craftables, index)
     } else {
-      // For depth > 1, run findReachableItems from each item and convert
       const seen = new Set<string>()
       results = []
       for (const item of req.craftables) {
@@ -67,7 +187,6 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
           seen.add(key)
           const lastStep = r.path[r.path.length - 1]
           const resultMatTier = MATERIAL_TIER[r.item.material] ?? 0
-          // Compare against the original source item's material
           const sourceMatTier = MATERIAL_TIER[item.material] ?? 0
           const materialUpgrade = resultMatTier > sourceMatTier
           const matScore = resultMatTier * 10
@@ -79,7 +198,20 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
             steps: r.depth,
             score: matScore + upgradeBonus - r.depth * 3,
             materialUpgrade,
+            statDiff: null,
           })
+        }
+      }
+      results.sort((a, b) => b.score - a.score)
+    }
+
+    // Compute stat diffs if game data is available
+    if (bladeMap.size > 0 || armorMap.size > 0) {
+      for (const r of results) {
+        r.statDiff = computeStatDiff(r, bladeMap, armorMap, matMap)
+        // Boost score based on stat improvement
+        if (r.statDiff && r.statDiff.total > 0) {
+          r.score += r.statDiff.total * 2
         }
       }
       results.sort((a, b) => b.score - a.score)
@@ -96,7 +228,12 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
       { name: req.targetName, material: req.targetMaterial ?? null },
       req.craftables,
       index,
-      { maxDepth: 3, maxResults: 20, maxStates: 10000, ...req.config }
+      {
+        maxDepth: req.maxDepth ?? 3,
+        maxResults: 20,
+        maxStates: 10000,
+        ...req.config,
+      }
     )
     const response: WorkerResponse = {
       type: "reverse",

--- a/src/lib/crafting-worker.ts
+++ b/src/lib/crafting-worker.ts
@@ -7,6 +7,8 @@ import {
   buildRecipeIndex,
   findAllCraftableResults,
   findCraftingPaths,
+  findReachableItems,
+  MATERIAL_TIER,
   type CraftableItem,
   type CraftableResult,
   type CraftingPath,
@@ -21,6 +23,8 @@ export interface WorkerRequest {
   craftingRecipes: CraftingRecipe[]
   materialRecipes: MaterialRecipe[]
   craftables: CraftableItem[]
+  // Discover-specific
+  maxDepth?: number
   // Reverse-specific (find path to target)
   targetName?: string
   targetMaterial?: string | null
@@ -42,7 +46,37 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   const index = buildRecipeIndex(req.craftingRecipes, req.materialRecipes)
 
   if (req.type === "discover") {
-    const results = findAllCraftableResults(req.craftables, index)
+    const depth = req.maxDepth ?? 1
+    let results: CraftableResult[]
+
+    if (depth <= 1) {
+      results = findAllCraftableResults(req.craftables, index)
+    } else {
+      // For depth > 1, run findReachableItems from each item and convert
+      const seen = new Set<string>()
+      results = []
+      for (const item of req.craftables) {
+        const reachable = findReachableItems(item, req.craftables, index, {
+          maxDepth: depth,
+          maxResults: 100,
+          maxStates: 2000,
+        })
+        for (const r of reachable) {
+          const key = `${r.item.name}:${r.item.material}`
+          if (seen.has(key)) continue
+          seen.add(key)
+          const lastStep = r.path[r.path.length - 1]
+          const matScore = (MATERIAL_TIER[r.item.material] ?? 0) * 10
+          results.push({
+            result: r.item,
+            step: lastStep,
+            score: matScore - r.depth * 5,
+          })
+        }
+      }
+      results.sort((a, b) => b.score - a.score)
+    }
+
     const response: WorkerResponse = {
       type: "discover",
       discoverResults: results,

--- a/src/lib/crafting-worker.ts
+++ b/src/lib/crafting-worker.ts
@@ -75,6 +75,7 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
           results.push({
             result: r.item,
             step: lastStep,
+            path: r.path,
             steps: r.depth,
             score: matScore + upgradeBonus - r.depth * 3,
             materialUpgrade,

--- a/src/lib/crafting-worker.ts
+++ b/src/lib/crafting-worker.ts
@@ -5,35 +5,33 @@
 
 import {
   buildRecipeIndex,
+  findAllCraftableResults,
   findCraftingPaths,
-  findReachableItems,
   type CraftableItem,
+  type CraftableResult,
   type CraftingPath,
   type OptimizerConfig,
-  type ReachableItem,
 } from "./crafting-optimizer"
 import type { CraftingRecipe, MaterialRecipe } from "./game-api"
 
 // ── Message types ────────────────────────────────────────────────────
 
 export interface WorkerRequest {
-  type: "forward" | "reverse"
+  type: "discover" | "reverse"
   craftingRecipes: CraftingRecipe[]
   materialRecipes: MaterialRecipe[]
   craftables: CraftableItem[]
-  // Forward-specific
+  // Reverse-specific (find path to target)
   targetName?: string
   targetMaterial?: string | null
-  // Reverse-specific
-  sourceItem?: CraftableItem
   // Config
   config?: Partial<OptimizerConfig>
 }
 
 export interface WorkerResponse {
-  type: "forward" | "reverse"
-  forwardPaths?: CraftingPath[]
-  reverseResults?: ReachableItem[]
+  type: "discover" | "reverse"
+  discoverResults?: CraftableResult[]
+  reversePaths?: CraftingPath[]
   elapsed: number
 }
 
@@ -43,7 +41,15 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
 
   const index = buildRecipeIndex(req.craftingRecipes, req.materialRecipes)
 
-  if (req.type === "forward" && req.targetName) {
+  if (req.type === "discover") {
+    const results = findAllCraftableResults(req.craftables, index)
+    const response: WorkerResponse = {
+      type: "discover",
+      discoverResults: results,
+      elapsed: performance.now() - start,
+    }
+    self.postMessage(response)
+  } else if (req.type === "reverse" && req.targetName) {
     const paths = findCraftingPaths(
       { name: req.targetName, material: req.targetMaterial ?? null },
       req.craftables,
@@ -51,21 +57,8 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
       { maxDepth: 3, maxResults: 20, maxStates: 10000, ...req.config }
     )
     const response: WorkerResponse = {
-      type: "forward",
-      forwardPaths: paths,
-      elapsed: performance.now() - start,
-    }
-    self.postMessage(response)
-  } else if (req.type === "reverse" && req.sourceItem) {
-    const results = findReachableItems(req.sourceItem, req.craftables, index, {
-      maxDepth: 2,
-      maxResults: 50,
-      maxStates: 10000,
-      ...req.config,
-    })
-    const response: WorkerResponse = {
       type: "reverse",
-      reverseResults: results,
+      reversePaths: paths,
       elapsed: performance.now() - start,
     }
     self.postMessage(response)

--- a/src/lib/crafting-worker.ts
+++ b/src/lib/crafting-worker.ts
@@ -66,11 +66,18 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
           if (seen.has(key)) continue
           seen.add(key)
           const lastStep = r.path[r.path.length - 1]
-          const matScore = (MATERIAL_TIER[r.item.material] ?? 0) * 10
+          const resultMatTier = MATERIAL_TIER[r.item.material] ?? 0
+          // Compare against the original source item's material
+          const sourceMatTier = MATERIAL_TIER[item.material] ?? 0
+          const materialUpgrade = resultMatTier > sourceMatTier
+          const matScore = resultMatTier * 10
+          const upgradeBonus = materialUpgrade ? 15 : 0
           results.push({
             result: r.item,
             step: lastStep,
-            score: matScore - r.depth * 5,
+            steps: r.depth,
+            score: matScore + upgradeBonus - r.depth * 3,
+            materialUpgrade,
           })
         }
       }

--- a/src/lib/save-import-mapper.ts
+++ b/src/lib/save-import-mapper.ts
@@ -34,14 +34,15 @@ import type {
 
 // ── Material mapping (must match save-parser.ts MATERIALS array) ─────
 
+// Material IDs in the save file are 1-based (0 = no material)
 const MATERIAL_BY_ID: Record<number, string> = {
-  0: "Wood",
-  1: "Leather",
-  2: "Bronze",
-  3: "Iron",
-  4: "Silver",
+  1: "Wood",
+  2: "Leather",
+  3: "Bronze",
+  4: "Iron",
   5: "Hagane",
-  6: "Damascus",
+  6: "Silver",
+  7: "Damascus",
 }
 
 // ── ITEMNAME.BIN → API id conversion ─────────────────────────────────

--- a/src/lib/save-parser.ts
+++ b/src/lib/save-parser.ts
@@ -22,14 +22,16 @@ const VS_BLOCKS_PER_SAVE = 3 // 3 blocks = 24,576 bytes allocated
 const MAGIC_VALUE = 0x20000107 // Post-decryption validation marker
 const LCG_MULTIPLIER = 0x19660d // Numerical Recipes LCG multiplier
 
+// Material IDs in save data are 1-based (0 = no material)
 const MATERIALS = [
-  "Wood",
-  "Leather",
-  "Bronze",
-  "Iron",
-  "Silver",
-  "Hagane",
-  "Damascus",
+  "", // 0 = none
+  "Wood", // 1
+  "Leather", // 2
+  "Bronze", // 3
+  "Iron", // 4
+  "Hagane", // 5
+  "Silver", // 6
+  "Damascus", // 7
 ] as const
 
 // ── Types ────────────────────────────────────────────────────────────

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -396,11 +396,21 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
 // ── Discover results (forward) ───────────────────────────────────────
 
 function DiscoverResults({ results }: { results: CraftableResult[] }) {
-  if (results.length === 0) {
+  // Only show results that are upgrades (material or tier)
+  const upgrades = results.filter(
+    (r) => r.materialUpgrade || r.step.recipe.tier_change > 0
+  )
+
+  if (upgrades.length === 0) {
     return (
       <div className="text-muted-foreground py-6 text-center text-sm">
         <FlaskConical className="mx-auto mb-2 size-8 opacity-30" />
-        <p>No combinations found with your current inventory</p>
+        <p>No upgrades found with your current inventory</p>
+        <p className="mt-1 text-xs">
+          {results.length > 0
+            ? `${results.length} combinations exist but none produce a material or tier upgrade`
+            : "No combinations found"}
+        </p>
       </div>
     )
   }
@@ -408,26 +418,44 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
   return (
     <div className="space-y-3">
       <p className="text-muted-foreground text-xs">
-        {results.length} possible result{results.length !== 1 ? "s" : ""} — top
-        results shown first
+        {upgrades.length} upgrade{upgrades.length !== 1 ? "s" : ""} found
+        {results.length > upgrades.length && (
+          <span>
+            {" "}
+            ({results.length - upgrades.length} lateral moves hidden)
+          </span>
+        )}
       </p>
       <div className="space-y-2">
-        {results.slice(0, 20).map((r, i) => (
-          <Card
-            key={i}
-            className={cn("transition-colors", i < 3 && "border-primary/30")}
-          >
-            <CardContent className="flex items-center gap-3 p-3">
-              {i < 3 && (
-                <span className="text-primary text-xs font-bold">#{i + 1}</span>
-              )}
+        {upgrades.slice(0, 30).map((r, i) => (
+          <Card key={i} className="transition-colors">
+            <CardContent className="flex flex-wrap items-center gap-2 p-3">
+              {/* Result */}
               <div className="flex items-center gap-2">
                 <ItemIcon type={r.result.equipType} size="sm" />
                 <span className="text-sm font-medium">{r.result.name}</span>
                 {r.result.material && <MaterialBadge mat={r.result.material} />}
               </div>
-              <ChevronRight className="text-muted-foreground size-3" />
-              <div className="text-muted-foreground flex items-center gap-1 text-xs">
+
+              {/* Badges */}
+              {r.materialUpgrade && (
+                <span className="rounded bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-green-400">
+                  MAT UPGRADE
+                </span>
+              )}
+              {r.step.recipe.tier_change > 0 && (
+                <span className="bg-primary/15 text-primary rounded px-1.5 py-0.5 text-[10px] font-semibold">
+                  TIER UP
+                </span>
+              )}
+              {r.steps > 1 && (
+                <span className="text-muted-foreground text-[10px]">
+                  {r.steps} steps
+                </span>
+              )}
+
+              {/* Recipe */}
+              <div className="text-muted-foreground ml-auto flex items-center gap-1 text-xs">
                 <span>{r.step.input1.name}</span>
                 {r.step.input1.material && (
                   <MaterialBadge mat={r.step.input1.material} />
@@ -438,11 +466,6 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
                   <MaterialBadge mat={r.step.input2.material} />
                 )}
               </div>
-              {r.step.recipe.tier_change > 0 && (
-                <span className="text-primary ml-auto text-[10px] font-semibold">
-                  UPGRADE
-                </span>
-              )}
             </CardContent>
           </Card>
         ))}

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -170,11 +170,30 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   const runForwardSearch = () => {
     if (!recipesReady || !targetItem) return
     setForwardSearched(false)
+
+    // Determine target category and only send relevant items + recipes
+    const blade = blades.find((b) => b.name === targetItem)
+    const armorItem = armor.find((a) => a.name === targetItem)
+    const targetCategory = blade
+      ? "blade"
+      : armorItem?.armor_type === "Shield"
+        ? "shield"
+        : armorItem
+          ? "armor"
+          : "blade"
+
+    const filteredCraftables = craftables.filter(
+      (c) => c.category === targetCategory
+    )
+    const filteredRecipes = craftingRecipes.filter(
+      (r) => r.category === targetCategory
+    )
+
     postWorker({
       type: "forward",
-      craftingRecipes,
+      craftingRecipes: filteredRecipes,
       materialRecipes,
-      craftables,
+      craftables: filteredCraftables,
       targetName: targetItem,
       targetMaterial,
     })
@@ -190,11 +209,19 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   const runReverseSearch = () => {
     if (!recipesReady || !reverseSource) return
     setReverseSearched(false)
+
+    const filteredCraftables = craftables.filter(
+      (c) => c.category === reverseSource.category
+    )
+    const filteredRecipes = craftingRecipes.filter(
+      (r) => r.category === reverseSource.category
+    )
+
     postWorker({
       type: "reverse",
-      craftingRecipes,
+      craftingRecipes: filteredRecipes,
       materialRecipes,
-      craftables,
+      craftables: filteredCraftables,
       sourceItem: reverseSource,
     })
   }

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -402,17 +402,60 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
 
 // ── Discover results (forward) ───────────────────────────────────────
 
+type DiscoverSort = "score" | "material" | "stats" | "steps"
+type DiscoverFilter = "all" | "mat-upgrade" | "tier-up" | "stat-up"
+
+const MATERIAL_ORDER: Record<string, number> = {
+  Wood: 0,
+  Leather: 1,
+  Bronze: 2,
+  Iron: 3,
+  Hagane: 4,
+  Silver: 5,
+  Damascus: 6,
+}
+
 function DiscoverResults({ results }: { results: CraftableResult[] }) {
   const [showAll, setShowAll] = useState(false)
+  const [sortBy, setSortBy] = useState<DiscoverSort>("score")
+  const [filterBy, setFilterBy] = useState<DiscoverFilter>("all")
   const PAGE_SIZE = 20
 
   // Only show results that are upgrades (material or tier or stat improvement)
-  const upgrades = results.filter(
-    (r) =>
-      r.materialUpgrade ||
-      r.step.recipe.tier_change > 0 ||
-      (r.statDiff && r.statDiff.total > 0)
-  )
+  const upgrades = useMemo(() => {
+    let filtered = results.filter(
+      (r) =>
+        r.materialUpgrade ||
+        r.step.recipe.tier_change > 0 ||
+        (r.statDiff && r.statDiff.total > 0)
+    )
+
+    // Apply user filter
+    if (filterBy === "mat-upgrade") {
+      filtered = filtered.filter((r) => r.materialUpgrade)
+    } else if (filterBy === "tier-up") {
+      filtered = filtered.filter((r) => r.step.recipe.tier_change > 0)
+    } else if (filterBy === "stat-up") {
+      filtered = filtered.filter((r) => r.statDiff && r.statDiff.total > 0)
+    }
+
+    // Apply sort
+    return [...filtered].sort((a, b) => {
+      if (sortBy === "material") {
+        return (
+          (MATERIAL_ORDER[b.result.material] ?? 0) -
+          (MATERIAL_ORDER[a.result.material] ?? 0)
+        )
+      }
+      if (sortBy === "stats") {
+        return (b.statDiff?.total ?? 0) - (a.statDiff?.total ?? 0)
+      }
+      if (sortBy === "steps") {
+        return a.steps - b.steps
+      }
+      return b.score - a.score
+    })
+  }, [results, sortBy, filterBy])
 
   if (upgrades.length === 0) {
     return (
@@ -421,7 +464,7 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
         <p>No upgrades found with your current inventory</p>
         <p className="mt-1 text-xs">
           {results.length > 0
-            ? `${results.length} combinations exist but none produce an upgrade`
+            ? `${results.length} combinations exist but none match the filter`
             : "No combinations found"}
         </p>
       </div>
@@ -433,16 +476,41 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
 
   return (
     <div className="space-y-3">
-      <p className="text-muted-foreground text-xs">
-        Showing {visible.length} of {upgrades.length} upgrade
-        {upgrades.length !== 1 ? "s" : ""}
-        {results.length > upgrades.length && (
-          <span>
-            {" "}
-            ({results.length - upgrades.length} lateral moves hidden)
-          </span>
-        )}
-      </p>
+      {/* Sort + filter controls */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={sortBy}
+          onValueChange={(v) => setSortBy(v as DiscoverSort)}
+        >
+          <SelectTrigger className="h-8 w-auto min-w-[7rem] text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="score">Best Overall</SelectItem>
+            <SelectItem value="material">Material Tier</SelectItem>
+            <SelectItem value="stats">Stat Gain</SelectItem>
+            <SelectItem value="steps">Fewest Steps</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={filterBy}
+          onValueChange={(v) => setFilterBy(v as DiscoverFilter)}
+        >
+          <SelectTrigger className="h-8 w-auto min-w-[7rem] text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Upgrades</SelectItem>
+            <SelectItem value="mat-upgrade">Material Upgrades</SelectItem>
+            <SelectItem value="tier-up">Tier Up Only</SelectItem>
+            <SelectItem value="stat-up">Stat Gains Only</SelectItem>
+          </SelectContent>
+        </Select>
+        <span className="text-muted-foreground text-xs">
+          {upgrades.length} result{upgrades.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
       <div className="space-y-2">
         {visible.map((r, i) => (
           <DiscoverCard key={i} result={r} />

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -428,49 +428,112 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
       </p>
       <div className="space-y-2">
         {upgrades.slice(0, 30).map((r, i) => (
-          <Card key={i} className="transition-colors">
-            <CardContent className="flex flex-wrap items-center gap-2 p-3">
-              {/* Result */}
-              <div className="flex items-center gap-2">
-                <ItemIcon type={r.result.equipType} size="sm" />
-                <span className="text-sm font-medium">{r.result.name}</span>
-                {r.result.material && <MaterialBadge mat={r.result.material} />}
-              </div>
-
-              {/* Badges */}
-              {r.materialUpgrade && (
-                <span className="rounded bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-green-400">
-                  MAT UPGRADE
-                </span>
-              )}
-              {r.step.recipe.tier_change > 0 && (
-                <span className="bg-primary/15 text-primary rounded px-1.5 py-0.5 text-[10px] font-semibold">
-                  TIER UP
-                </span>
-              )}
-              {r.steps > 1 && (
-                <span className="text-muted-foreground text-[10px]">
-                  {r.steps} steps
-                </span>
-              )}
-
-              {/* Recipe */}
-              <div className="text-muted-foreground ml-auto flex items-center gap-1 text-xs">
-                <span>{r.step.input1.name}</span>
-                {r.step.input1.material && (
-                  <MaterialBadge mat={r.step.input1.material} />
-                )}
-                <span>+</span>
-                <span>{r.step.input2.name}</span>
-                {r.step.input2.material && (
-                  <MaterialBadge mat={r.step.input2.material} />
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <DiscoverCard key={i} result={r} />
         ))}
       </div>
     </div>
+  )
+}
+
+function DiscoverCard({ result: r }: { result: CraftableResult }) {
+  const [expanded, setExpanded] = useState(false)
+  const isMultiStep = r.steps > 1
+
+  return (
+    <Card
+      className={cn("transition-colors", isMultiStep && "cursor-pointer")}
+      onClick={isMultiStep ? () => setExpanded(!expanded) : undefined}
+    >
+      <CardContent className="p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Result */}
+          <div className="flex items-center gap-2">
+            <ItemIcon type={r.result.equipType} size="sm" />
+            <span className="text-sm font-medium">{r.result.name}</span>
+            {r.result.material && <MaterialBadge mat={r.result.material} />}
+          </div>
+
+          {/* Badges */}
+          {r.materialUpgrade && (
+            <span className="rounded bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-green-400">
+              MAT UPGRADE
+            </span>
+          )}
+          {r.step.recipe.tier_change > 0 && (
+            <span className="bg-primary/15 text-primary rounded px-1.5 py-0.5 text-[10px] font-semibold">
+              TIER UP
+            </span>
+          )}
+          {isMultiStep && (
+            <span className="text-muted-foreground text-[10px]">
+              {r.steps} steps
+            </span>
+          )}
+
+          {/* Recipe (last step for 1-step, or summary) */}
+          <div className="text-muted-foreground ml-auto flex items-center gap-1 text-xs">
+            <span>{r.step.input1.name}</span>
+            {r.step.input1.material && (
+              <MaterialBadge mat={r.step.input1.material} />
+            )}
+            <span>+</span>
+            <span>{r.step.input2.name}</span>
+            {r.step.input2.material && (
+              <MaterialBadge mat={r.step.input2.material} />
+            )}
+          </div>
+
+          {isMultiStep && (
+            <ChevronRight
+              className={cn(
+                "text-muted-foreground size-4 transition-transform",
+                expanded && "rotate-90"
+              )}
+            />
+          )}
+        </div>
+
+        {/* Expanded steps */}
+        {expanded && isMultiStep && (
+          <div className="mt-3 space-y-2">
+            {r.path.map((step, i) => (
+              <div
+                key={i}
+                className="bg-muted/30 flex items-center gap-2 rounded-lg px-3 py-2 text-xs"
+              >
+                <span className="text-muted-foreground font-mono">
+                  {i + 1}.
+                </span>
+                <div className="flex items-center gap-1">
+                  <ItemIcon type={step.input1.equipType} size="sm" />
+                  <span className="font-medium">{step.input1.name}</span>
+                  {step.input1.material && (
+                    <MaterialBadge mat={step.input1.material} />
+                  )}
+                </div>
+                <span className="text-muted-foreground">+</span>
+                <div className="flex items-center gap-1">
+                  <ItemIcon type={step.input2.equipType} size="sm" />
+                  <span className="font-medium">{step.input2.name}</span>
+                  {step.input2.material && (
+                    <MaterialBadge mat={step.input2.material} />
+                  )}
+                </div>
+                <ChevronRight className="text-muted-foreground size-3" />
+                <div className="flex items-center gap-1">
+                  <span className="text-primary font-medium">
+                    {step.result.name}
+                  </span>
+                  {step.result.material && (
+                    <MaterialBadge mat={step.result.material} />
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -1,6 +1,13 @@
 import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { ChevronRight, FlaskConical, Settings2, Undo2 } from "lucide-react"
+import {
+  ChevronRight,
+  FlaskConical,
+  Search,
+  Settings2,
+  Undo2,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import {
   Select,
@@ -130,16 +137,22 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     return ALL_MATERIALS
   }, [targetItem, blades, armor])
 
-  // Forward search results
-  const forwardPaths = useMemo<CraftingPath[]>(() => {
-    if (!recipeIndex || !targetItem || mode !== "forward") return []
-    return findCraftingPaths(
-      { name: targetItem, material: targetMaterial },
-      craftables,
-      recipeIndex,
-      { maxDepth: 4, maxResults: 20 }
+  // Forward search — triggered by button click
+  const [forwardPaths, setForwardPaths] = useState<CraftingPath[]>([])
+  const [forwardSearched, setForwardSearched] = useState(false)
+
+  const runForwardSearch = () => {
+    if (!recipeIndex || !targetItem) return
+    setForwardSearched(true)
+    setForwardPaths(
+      findCraftingPaths(
+        { name: targetItem, material: targetMaterial },
+        craftables,
+        recipeIndex,
+        { maxDepth: 3, maxResults: 20, maxStates: 5000 }
+      )
     )
-  }, [recipeIndex, targetItem, targetMaterial, craftables, mode])
+  }
 
   // ── Reverse mode: source selection + search ────────────────────────
 
@@ -148,13 +161,20 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     [craftables, reverseSourceId]
   )
 
-  const reverseResults = useMemo<ReachableItem[]>(() => {
-    if (!recipeIndex || !reverseSource || mode !== "reverse") return []
-    return findReachableItems(reverseSource, craftables, recipeIndex, {
-      maxDepth: 3,
-      maxResults: 50,
-    })
-  }, [recipeIndex, reverseSource, craftables, mode])
+  const [reverseResults, setReverseResults] = useState<ReachableItem[]>([])
+  const [reverseSearched, setReverseSearched] = useState(false)
+
+  const runReverseSearch = () => {
+    if (!recipeIndex || !reverseSource) return
+    setReverseSearched(true)
+    setReverseResults(
+      findReachableItems(reverseSource, craftables, recipeIndex, {
+        maxDepth: 2,
+        maxResults: 50,
+        maxStates: 5000,
+      })
+    )
+  }
 
   // ── Render ─────────────────────────────────────────────────────────
 
@@ -233,6 +253,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 onSelect={(name) => {
                   setTargetItem(name)
                   setTargetMaterial(null)
+                  setForwardSearched(false)
                 }}
                 placeholder="Select target item..."
                 label="Target"
@@ -243,18 +264,27 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 <MaterialSelect
                   materials={targetMaterials}
                   value={targetMaterial}
-                  onSelect={setTargetMaterial}
+                  onSelect={(m) => {
+                    setTargetMaterial(m)
+                    setForwardSearched(false)
+                  }}
                   label="Material (optional)"
                 />
               </div>
             )}
+            {targetItem && recipeIndex && (
+              <Button onClick={runForwardSearch} size="sm">
+                <Search className="size-3.5" />
+                Find Paths
+              </Button>
+            )}
           </div>
 
           {/* Results */}
-          {targetItem && recipeIndex && (
+          {forwardSearched && (
             <ForwardResults
               paths={forwardPaths}
-              targetName={targetItem}
+              targetName={targetItem ?? ""}
               targetMaterial={targetMaterial}
             />
           )}
@@ -273,7 +303,10 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 <button
                   key={c.id}
                   type="button"
-                  onClick={() => setReverseSourceId(c.id)}
+                  onClick={() => {
+                    setReverseSourceId(c.id)
+                    setReverseSearched(false)
+                  }}
                   className={cn(
                     "flex items-center gap-1.5 rounded-lg border px-2 py-1.5 text-xs transition-colors",
                     reverseSourceId === c.id
@@ -290,6 +323,13 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
           </div>
 
           {reverseSource && recipeIndex && (
+            <Button onClick={runReverseSearch} size="sm">
+              <Search className="size-3.5" />
+              Find Craftable Items
+            </Button>
+          )}
+
+          {reverseSearched && reverseSource && (
             <ReverseResults
               results={reverseResults}
               sourceName={reverseSource.name}

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -403,9 +403,15 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
 // ── Discover results (forward) ───────────────────────────────────────
 
 function DiscoverResults({ results }: { results: CraftableResult[] }) {
-  // Only show results that are upgrades (material or tier)
+  const [showAll, setShowAll] = useState(false)
+  const PAGE_SIZE = 20
+
+  // Only show results that are upgrades (material or tier or stat improvement)
   const upgrades = results.filter(
-    (r) => r.materialUpgrade || r.step.recipe.tier_change > 0
+    (r) =>
+      r.materialUpgrade ||
+      r.step.recipe.tier_change > 0 ||
+      (r.statDiff && r.statDiff.total > 0)
   )
 
   if (upgrades.length === 0) {
@@ -415,17 +421,21 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
         <p>No upgrades found with your current inventory</p>
         <p className="mt-1 text-xs">
           {results.length > 0
-            ? `${results.length} combinations exist but none produce a material or tier upgrade`
+            ? `${results.length} combinations exist but none produce an upgrade`
             : "No combinations found"}
         </p>
       </div>
     )
   }
 
+  const visible = showAll ? upgrades : upgrades.slice(0, PAGE_SIZE)
+  const hasMore = upgrades.length > PAGE_SIZE && !showAll
+
   return (
     <div className="space-y-3">
       <p className="text-muted-foreground text-xs">
-        {upgrades.length} upgrade{upgrades.length !== 1 ? "s" : ""} found
+        Showing {visible.length} of {upgrades.length} upgrade
+        {upgrades.length !== 1 ? "s" : ""}
         {results.length > upgrades.length && (
           <span>
             {" "}
@@ -434,10 +444,20 @@ function DiscoverResults({ results }: { results: CraftableResult[] }) {
         )}
       </p>
       <div className="space-y-2">
-        {upgrades.slice(0, 30).map((r, i) => (
+        {visible.map((r, i) => (
           <DiscoverCard key={i} result={r} />
         ))}
       </div>
+      {hasMore && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowAll(true)}
+          className="w-full"
+        >
+          Show all {upgrades.length} results
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -6,7 +6,6 @@ import {
   Loader2,
   Search,
   Settings2,
-  Undo2,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -25,13 +24,13 @@ import { gameApi, type Armor, type Blade } from "@/lib/game-api"
 import type { InventoryItem } from "@/lib/inventory-api"
 import {
   inventoryToCraftables,
+  type CraftableResult,
   type CraftingPath,
-  type ReachableItem,
 } from "@/lib/crafting-optimizer"
 import type { WorkerRequest, WorkerResponse } from "@/lib/crafting-worker"
 import { cn } from "@/lib/utils"
 
-// ── Materials available per workshop ─────────────────────────────────
+// ── Materials ────────────────────────────────────────────────────────
 
 const BLADE_MATS = ["Bronze", "Iron", "Hagane", "Silver", "Damascus"]
 const ALL_MATERIALS = [
@@ -47,6 +46,7 @@ const ALL_MATERIALS = [
 // ── Types ────────────────────────────────────────────────────────────
 
 type Mode = "forward" | "reverse"
+type Category = "blade" | "shield" | "armor"
 
 interface CraftingTabProps {
   items: InventoryItem[]
@@ -58,13 +58,15 @@ interface CraftingTabProps {
 
 export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   const [mode, setMode] = useState<Mode>("forward")
-  const [workshopId, setWorkshopId] = useState<string>("6") // Godhands default
+  const [workshopId, setWorkshopId] = useState<string>("6")
   const [includeEquipped, setIncludeEquipped] = useState(true)
+  const [forwardCategory, setForwardCategory] = useState<Category>("blade")
+
+  // Reverse mode state
   const [targetItem, setTargetItem] = useState<string | null>(null)
   const [targetMaterial, setTargetMaterial] = useState<string | null>(null)
-  const [reverseSourceId, setReverseSourceId] = useState<number | null>(null)
 
-  // Fetch workshops and recipes
+  // Fetch data
   const { data: workshops = [] } = useQuery({
     queryKey: ["workshops"],
     queryFn: gameApi.workshops,
@@ -80,24 +82,23 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
 
   const recipesReady = craftingRecipes.length > 0 && materialRecipes.length > 0
 
-  // Convert inventory to craftable items
   const craftables = useMemo(() => {
     const all = inventoryToCraftables(items, blades, armor)
     if (includeEquipped) return all
     return all.filter((c) => !c.sourceItem?.equip_slot)
   }, [items, blades, armor, includeEquipped])
 
-  // ── Search state (declared before worker so refs can access them) ──
+  // ── Search state ───────────────────────────────────────────────────
 
-  const [forwardPaths, setForwardPaths] = useState<CraftingPath[]>([])
-  const [forwardSearched, setForwardSearched] = useState(false)
-  const [reverseResults, setReverseResults] = useState<ReachableItem[]>([])
+  const [discoverResults, setDiscoverResults] = useState<CraftableResult[]>([])
+  const [discoverSearched, setDiscoverSearched] = useState(false)
+  const [reversePaths, setReversePaths] = useState<CraftingPath[]>([])
   const [reverseSearched, setReverseSearched] = useState(false)
+  const [searching, setSearching] = useState(false)
 
   // ── Web Worker ─────────────────────────────────────────────────────
 
   const workerRef = useRef<Worker | null>(null)
-  const [searching, setSearching] = useState(false)
 
   useEffect(() => {
     const worker = new Worker(
@@ -107,11 +108,11 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
       const res = e.data
       setSearching(false)
-      if (res.type === "forward" && res.forwardPaths) {
-        setForwardPaths(res.forwardPaths)
-        setForwardSearched(true)
-      } else if (res.type === "reverse" && res.reverseResults) {
-        setReverseResults(res.reverseResults)
+      if (res.type === "discover" && res.discoverResults) {
+        setDiscoverResults(res.discoverResults)
+        setDiscoverSearched(true)
+      } else if (res.type === "reverse" && res.reversePaths) {
+        setReversePaths(res.reversePaths)
         setReverseSearched(true)
       }
     }
@@ -125,7 +126,24 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     workerRef.current.postMessage(req)
   }, [])
 
-  // ── Forward mode: picker items + search ────────────────────────────
+  // ── Forward: discover what you can make ────────────────────────────
+
+  const runDiscover = () => {
+    if (!recipesReady) return
+    setDiscoverSearched(false)
+    const filtered = craftables.filter((c) => c.category === forwardCategory)
+    const filteredRecipes = craftingRecipes.filter(
+      (r) => r.category === forwardCategory
+    )
+    postWorker({
+      type: "discover",
+      craftingRecipes: filteredRecipes,
+      materialRecipes,
+      craftables: filtered,
+    })
+  }
+
+  // ── Reverse: find path to a target ─────────────────────────────────
 
   const bladePickerItems: PickerItem[] = useMemo(
     () =>
@@ -153,7 +171,6 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     [bladePickerItems, armorPickerItems]
   )
 
-  // Determine available materials for target
   const targetMaterials = useMemo(() => {
     if (!targetItem) return []
     const blade = blades.find((b) => b.name === targetItem)
@@ -166,63 +183,30 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     return ALL_MATERIALS
   }, [targetItem, blades, armor])
 
-  // Forward search — triggered by button click, runs in worker
-  const runForwardSearch = () => {
+  const runReverse = () => {
     if (!recipesReady || !targetItem) return
-    setForwardSearched(false)
+    setReverseSearched(false)
 
-    // Determine target category and only send relevant items + recipes
     const blade = blades.find((b) => b.name === targetItem)
     const armorItem = armor.find((a) => a.name === targetItem)
     const targetCategory = blade
       ? "blade"
       : armorItem?.armor_type === "Shield"
         ? "shield"
-        : armorItem
-          ? "armor"
-          : "blade"
+        : "armor"
 
-    const filteredCraftables = craftables.filter(
-      (c) => c.category === targetCategory
-    )
+    const filtered = craftables.filter((c) => c.category === targetCategory)
     const filteredRecipes = craftingRecipes.filter(
       (r) => r.category === targetCategory
-    )
-
-    postWorker({
-      type: "forward",
-      craftingRecipes: filteredRecipes,
-      materialRecipes,
-      craftables: filteredCraftables,
-      targetName: targetItem,
-      targetMaterial,
-    })
-  }
-
-  // ── Reverse mode: source selection + search ────────────────────────
-
-  const reverseSource = useMemo(
-    () => craftables.find((c) => c.id === reverseSourceId) ?? null,
-    [craftables, reverseSourceId]
-  )
-
-  const runReverseSearch = () => {
-    if (!recipesReady || !reverseSource) return
-    setReverseSearched(false)
-
-    const filteredCraftables = craftables.filter(
-      (c) => c.category === reverseSource.category
-    )
-    const filteredRecipes = craftingRecipes.filter(
-      (r) => r.category === reverseSource.category
     )
 
     postWorker({
       type: "reverse",
       craftingRecipes: filteredRecipes,
       materialRecipes,
-      craftables: filteredCraftables,
-      sourceItem: reverseSource,
+      craftables: filtered,
+      targetName: targetItem,
+      targetMaterial,
     })
   }
 
@@ -232,7 +216,6 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     <div className="space-y-4">
       {/* Controls row */}
       <div className="flex flex-wrap items-center gap-3">
-        {/* Workshop selector */}
         <Select value={workshopId} onValueChange={setWorkshopId}>
           <SelectTrigger className="h-9 w-auto min-w-[12rem]">
             <Settings2 className="mr-1.5 size-3.5" />
@@ -252,7 +235,6 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
           </SelectContent>
         </Select>
 
-        {/* Mode toggle */}
         <div className="flex rounded-lg border">
           <button
             type="button"
@@ -264,7 +246,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 : "text-muted-foreground hover:text-foreground"
             )}
           >
-            Forward
+            What Can I Make?
           </button>
           <button
             type="button"
@@ -276,11 +258,10 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 : "text-muted-foreground hover:text-foreground"
             )}
           >
-            Reverse
+            How Do I Make...?
           </button>
         </div>
 
-        {/* Include equipped toggle */}
         <label className="flex items-center gap-2 text-xs">
           <input
             type="checkbox"
@@ -292,8 +273,50 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
         </label>
       </div>
 
-      {/* Forward mode */}
+      {/* Forward: What Can I Make? */}
       {mode === "forward" && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <Select
+              value={forwardCategory}
+              onValueChange={(v) => {
+                setForwardCategory(v as Category)
+                setDiscoverSearched(false)
+              }}
+            >
+              <SelectTrigger className="h-9 w-auto min-w-[8rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="blade">Blades</SelectItem>
+                <SelectItem value="shield">Shields</SelectItem>
+                <SelectItem value="armor">Armor</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              onClick={runDiscover}
+              size="sm"
+              disabled={searching || !recipesReady}
+            >
+              {searching ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Search className="size-3.5" />
+              )}
+              {searching ? "Searching..." : "Find Best Results"}
+            </Button>
+            <span className="text-muted-foreground text-xs">
+              {craftables.filter((c) => c.category === forwardCategory).length}{" "}
+              items in inventory
+            </span>
+          </div>
+
+          {discoverSearched && <DiscoverResults results={discoverResults} />}
+        </div>
+      )}
+
+      {/* Reverse: How Do I Make...? */}
+      {mode === "reverse" && (
         <div className="space-y-4">
           <div className="flex flex-wrap items-end gap-3">
             <div className="min-w-[14rem] flex-1">
@@ -303,10 +326,10 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 onSelect={(name) => {
                   setTargetItem(name)
                   setTargetMaterial(null)
-                  setForwardSearched(false)
+                  setReverseSearched(false)
                 }}
                 placeholder="Select target item..."
-                label="Target"
+                label="I want to make..."
               />
             </div>
             {targetItem && targetMaterials.length > 0 && (
@@ -316,14 +339,14 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                   value={targetMaterial}
                   onSelect={(m) => {
                     setTargetMaterial(m)
-                    setForwardSearched(false)
+                    setReverseSearched(false)
                   }}
                   label="Material (optional)"
                 />
               </div>
             )}
             {targetItem && recipesReady && (
-              <Button onClick={runForwardSearch} size="sm" disabled={searching}>
+              <Button onClick={runReverse} size="sm" disabled={searching}>
                 {searching ? (
                   <Loader2 className="size-3.5 animate-spin" />
                 ) : (
@@ -334,10 +357,9 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
             )}
           </div>
 
-          {/* Results */}
-          {forwardSearched && (
-            <ForwardResults
-              paths={forwardPaths}
+          {reverseSearched && (
+            <ReverseResults
+              paths={reversePaths}
               targetName={targetItem ?? ""}
               targetMaterial={targetMaterial}
             />
@@ -345,58 +367,6 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
         </div>
       )}
 
-      {/* Reverse mode */}
-      {mode === "reverse" && (
-        <div className="space-y-4">
-          <div>
-            <label className="text-muted-foreground mb-1 block text-xs font-medium">
-              Select an item from your inventory
-            </label>
-            <div className="flex flex-wrap gap-2">
-              {craftables.map((c) => (
-                <button
-                  key={c.id}
-                  type="button"
-                  onClick={() => {
-                    setReverseSourceId(c.id)
-                    setReverseSearched(false)
-                  }}
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-lg border px-2 py-1.5 text-xs transition-colors",
-                    reverseSourceId === c.id
-                      ? "border-primary bg-primary/10"
-                      : "border-border/50 hover:border-foreground/30"
-                  )}
-                >
-                  <ItemIcon type={c.equipType} size="sm" />
-                  <span className="font-medium">{c.name}</span>
-                  {c.material && <MaterialBadge mat={c.material} />}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {reverseSource && recipesReady && (
-            <Button onClick={runReverseSearch} size="sm" disabled={searching}>
-              {searching ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                <Search className="size-3.5" />
-              )}
-              {searching ? "Searching..." : "Find Craftable Items"}
-            </Button>
-          )}
-
-          {reverseSearched && reverseSource && (
-            <ReverseResults
-              results={reverseResults}
-              sourceName={reverseSource.name}
-            />
-          )}
-        </div>
-      )}
-
-      {/* Empty state */}
       {!recipesReady && (
         <p className="text-muted-foreground py-8 text-center text-sm">
           Loading crafting recipes...
@@ -406,9 +376,67 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   )
 }
 
-// ── Forward results ──────────────────────────────────────────────────
+// ── Discover results (forward) ───────────────────────────────────────
 
-function ForwardResults({
+function DiscoverResults({ results }: { results: CraftableResult[] }) {
+  if (results.length === 0) {
+    return (
+      <div className="text-muted-foreground py-6 text-center text-sm">
+        <FlaskConical className="mx-auto mb-2 size-8 opacity-30" />
+        <p>No combinations found with your current inventory</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-xs">
+        {results.length} possible result{results.length !== 1 ? "s" : ""} — top
+        results shown first
+      </p>
+      <div className="space-y-2">
+        {results.slice(0, 20).map((r, i) => (
+          <Card
+            key={i}
+            className={cn("transition-colors", i < 3 && "border-primary/30")}
+          >
+            <CardContent className="flex items-center gap-3 p-3">
+              {i < 3 && (
+                <span className="text-primary text-xs font-bold">#{i + 1}</span>
+              )}
+              <div className="flex items-center gap-2">
+                <ItemIcon type={r.result.equipType} size="sm" />
+                <span className="text-sm font-medium">{r.result.name}</span>
+                {r.result.material && <MaterialBadge mat={r.result.material} />}
+              </div>
+              <ChevronRight className="text-muted-foreground size-3" />
+              <div className="text-muted-foreground flex items-center gap-1 text-xs">
+                <span>{r.step.input1.name}</span>
+                {r.step.input1.material && (
+                  <MaterialBadge mat={r.step.input1.material} />
+                )}
+                <span>+</span>
+                <span>{r.step.input2.name}</span>
+                {r.step.input2.material && (
+                  <MaterialBadge mat={r.step.input2.material} />
+                )}
+              </div>
+              {r.step.recipe.tier_change > 0 && (
+                <span className="text-primary ml-auto text-[10px] font-semibold">
+                  UPGRADE
+                </span>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Reverse results (find path to target) ────────────────────────────
+
+function ReverseResults({
   paths,
   targetName,
   targetMaterial,
@@ -463,7 +491,6 @@ function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
       onClick={() => setExpanded(!expanded)}
     >
       <CardContent className="p-3">
-        {/* Header */}
         <div className="flex items-center gap-3">
           <span className="text-muted-foreground font-mono text-xs">
             #{rank}
@@ -485,7 +512,6 @@ function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
           />
         </div>
 
-        {/* Steps */}
         {expanded && (
           <div className="mt-3 space-y-2">
             {path.steps.map((step, i) => (
@@ -523,7 +549,6 @@ function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
               </div>
             ))}
 
-            {/* Consumed items summary */}
             <div className="text-muted-foreground pt-1 text-[11px]">
               Consumes:{" "}
               {path.consumedItems
@@ -535,75 +560,5 @@ function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
         )}
       </CardContent>
     </Card>
-  )
-}
-
-// ── Reverse results ──────────────────────────────────────────────────
-
-function ReverseResults({
-  results,
-  sourceName,
-}: {
-  results: ReachableItem[]
-  sourceName: string
-}) {
-  if (results.length === 0) {
-    return (
-      <div className="text-muted-foreground py-6 text-center text-sm">
-        <Undo2 className="mx-auto mb-2 size-8 opacity-30" />
-        <p>
-          No crafting options found for{" "}
-          <span className="font-medium">{sourceName}</span>
-        </p>
-        <p className="mt-1 text-xs">
-          This item can't be combined with anything in your current inventory
-        </p>
-      </div>
-    )
-  }
-
-  // Group by depth
-  const byDepth = new Map<number, ReachableItem[]>()
-  for (const r of results) {
-    const list = byDepth.get(r.depth) ?? []
-    list.push(r)
-    byDepth.set(r.depth, list)
-  }
-
-  return (
-    <div className="space-y-4">
-      <p className="text-muted-foreground text-xs">
-        {results.length} reachable item{results.length !== 1 ? "s" : ""} from{" "}
-        <span className="font-medium">{sourceName}</span>
-      </p>
-
-      {[...byDepth.entries()].map(([depth, items]) => (
-        <div key={depth}>
-          <p className="text-muted-foreground mb-2 text-xs font-medium">
-            {depth} step{depth !== 1 ? "s" : ""}
-          </p>
-          <div className="space-y-1">
-            {items.map((r, i) => (
-              <div
-                key={i}
-                className="border-border/50 flex items-center gap-2 rounded-lg border px-3 py-2"
-              >
-                <ItemIcon type={r.item.equipType} size="sm" />
-                <span className="text-sm font-medium">{r.item.name}</span>
-                {r.item.material && <MaterialBadge mat={r.item.material} />}
-                <span className="text-muted-foreground ml-auto text-xs">
-                  {r.path
-                    .map(
-                      (s) =>
-                        `${s.input1.name} + ${s.input2.name} → ${s.result.name}`
-                    )
-                    .join(" → ")}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
   )
 }

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -61,7 +61,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   const [workshopId, setWorkshopId] = useState<string>("6")
   const [includeEquipped, setIncludeEquipped] = useState(true)
   const [forwardCategory, setForwardCategory] = useState<Category>("blade")
-  const [forwardDepth, setForwardDepth] = useState<number>(1)
+  const [searchDepth, setSearchDepth] = useState<number>(1)
 
   // Reverse mode state
   const [targetItem, setTargetItem] = useState<string | null>(null)
@@ -79,6 +79,11 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   const { data: materialRecipes = [] } = useQuery({
     queryKey: ["materialRecipes"],
     queryFn: () => gameApi.materialRecipes("limit=10000"),
+  })
+
+  const { data: materials = [] } = useQuery({
+    queryKey: ["materials"],
+    queryFn: gameApi.materials,
   })
 
   const recipesReady = craftingRecipes.length > 0 && materialRecipes.length > 0
@@ -141,7 +146,10 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
       craftingRecipes: filteredRecipes,
       materialRecipes,
       craftables: filtered,
-      maxDepth: forwardDepth,
+      blades,
+      armor,
+      materials,
+      maxDepth: searchDepth,
     })
   }
 
@@ -209,6 +217,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
       craftables: filtered,
       targetName: targetItem,
       targetMaterial,
+      maxDepth: searchDepth,
     })
   }
 
@@ -273,6 +282,19 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
           />
           <span className="text-muted-foreground">Include equipped</span>
         </label>
+
+        <Select
+          value={String(searchDepth)}
+          onValueChange={(v) => setSearchDepth(Number(v))}
+        >
+          <SelectTrigger className="h-9 w-auto min-w-[6rem]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="1">1 step</SelectItem>
+            <SelectItem value="2">2 steps</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Forward: What Can I Make? */}
@@ -293,21 +315,6 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 <SelectItem value="blade">Blades</SelectItem>
                 <SelectItem value="shield">Shields</SelectItem>
                 <SelectItem value="armor">Armor</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select
-              value={String(forwardDepth)}
-              onValueChange={(v) => {
-                setForwardDepth(Number(v))
-                setDiscoverSearched(false)
-              }}
-            >
-              <SelectTrigger className="h-9 w-auto min-w-[6rem]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="1">1 step</SelectItem>
-                <SelectItem value="2">2 steps</SelectItem>
               </SelectContent>
             </Select>
             <Button
@@ -470,6 +477,42 @@ function DiscoverCard({ result: r }: { result: CraftableResult }) {
             </span>
           )}
 
+          {/* Stat diff */}
+          {r.statDiff && (
+            <div className="flex items-center gap-1.5 text-[10px] font-medium">
+              {r.statDiff.str !== 0 && (
+                <span
+                  className={
+                    r.statDiff.str > 0 ? "text-green-400" : "text-red-400"
+                  }
+                >
+                  STR {r.statDiff.str > 0 ? "+" : ""}
+                  {r.statDiff.str}
+                </span>
+              )}
+              {r.statDiff.int !== 0 && (
+                <span
+                  className={
+                    r.statDiff.int > 0 ? "text-green-400" : "text-red-400"
+                  }
+                >
+                  INT {r.statDiff.int > 0 ? "+" : ""}
+                  {r.statDiff.int}
+                </span>
+              )}
+              {r.statDiff.agi !== 0 && (
+                <span
+                  className={
+                    r.statDiff.agi > 0 ? "text-green-400" : "text-red-400"
+                  }
+                >
+                  AGI {r.statDiff.agi > 0 ? "+" : ""}
+                  {r.statDiff.agi}
+                </span>
+              )}
+            </div>
+          )}
+
           {/* Recipe (last step for 1-step, or summary) */}
           <div className="text-muted-foreground ml-auto flex items-center gap-1 text-xs">
             <span>{r.step.input1.name}</span>
@@ -583,39 +626,62 @@ function ReverseResults({
 }
 
 function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
-  const [expanded, setExpanded] = useState(rank === 1)
+  const isMultiStep = path.steps.length > 1
+  const [expanded, setExpanded] = useState(rank === 1 && isMultiStep)
 
+  // 1-step: show inline recipe. Multi-step: collapsible.
   return (
     <Card
       className={cn(
-        "cursor-pointer transition-colors",
+        "transition-colors",
+        isMultiStep && "cursor-pointer",
         rank === 1 && "border-primary/30"
       )}
-      onClick={() => setExpanded(!expanded)}
+      onClick={isMultiStep ? () => setExpanded(!expanded) : undefined}
     >
       <CardContent className="p-3">
-        <div className="flex items-center gap-3">
-          <span className="text-muted-foreground font-mono text-xs">
-            #{rank}
-          </span>
+        <div className="flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-2">
+            <ItemIcon type={path.result.equipType} size="sm" />
             <span className="text-sm font-medium">{path.result.name}</span>
             {path.result.material && (
               <MaterialBadge mat={path.result.material} />
             )}
           </div>
-          <span className="text-muted-foreground ml-auto text-xs">
-            {path.steps.length} step{path.steps.length !== 1 ? "s" : ""}
-          </span>
-          <ChevronRight
-            className={cn(
-              "text-muted-foreground size-4 transition-transform",
-              expanded && "rotate-90"
+          {isMultiStep && (
+            <span className="text-muted-foreground text-[10px]">
+              {path.steps.length} steps
+            </span>
+          )}
+
+          {/* Inline recipe for 1-step */}
+          <div className="text-muted-foreground ml-auto flex items-center gap-1 text-xs">
+            {!isMultiStep && path.steps[0] && (
+              <>
+                <span>{path.steps[0].input1.name}</span>
+                {path.steps[0].input1.material && (
+                  <MaterialBadge mat={path.steps[0].input1.material} />
+                )}
+                <span>+</span>
+                <span>{path.steps[0].input2.name}</span>
+                {path.steps[0].input2.material && (
+                  <MaterialBadge mat={path.steps[0].input2.material} />
+                )}
+              </>
             )}
-          />
+          </div>
+
+          {isMultiStep && (
+            <ChevronRight
+              className={cn(
+                "text-muted-foreground size-4 transition-transform",
+                expanded && "rotate-90"
+              )}
+            />
+          )}
         </div>
 
-        {expanded && (
+        {expanded && isMultiStep && (
           <div className="mt-3 space-y-2">
             {path.steps.map((step, i) => (
               <div

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -1,0 +1,511 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { ChevronRight, FlaskConical, Settings2, Undo2 } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ItemIcon } from "@/components/item-icon"
+import { MaterialBadge } from "@/components/stat-display"
+import { ItemPicker, type PickerItem } from "@/components/item-picker"
+import { MaterialSelect } from "@/components/material-select"
+import { gameApi, type Armor, type Blade } from "@/lib/game-api"
+import type { InventoryItem } from "@/lib/inventory-api"
+import {
+  buildRecipeIndex,
+  findCraftingPaths,
+  findReachableItems,
+  inventoryToCraftables,
+  type CraftingPath,
+  type ReachableItem,
+  type RecipeIndex,
+} from "@/lib/crafting-optimizer"
+import { cn } from "@/lib/utils"
+
+// ── Materials available per workshop ─────────────────────────────────
+
+const BLADE_MATS = ["Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+const ALL_MATERIALS = [
+  "Wood",
+  "Leather",
+  "Bronze",
+  "Iron",
+  "Hagane",
+  "Silver",
+  "Damascus",
+]
+
+// ── Types ────────────────────────────────────────────────────────────
+
+type Mode = "forward" | "reverse"
+
+interface CraftingTabProps {
+  items: InventoryItem[]
+  blades: Blade[]
+  armor: Armor[]
+}
+
+// ── Main component ───────────────────────────────────────────────────
+
+export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
+  const [mode, setMode] = useState<Mode>("forward")
+  const [workshopId, setWorkshopId] = useState<string>("6") // Godhands default
+  const [includeEquipped, setIncludeEquipped] = useState(true)
+  const [targetItem, setTargetItem] = useState<string | null>(null)
+  const [targetMaterial, setTargetMaterial] = useState<string | null>(null)
+  const [reverseSourceId, setReverseSourceId] = useState<number | null>(null)
+
+  // Fetch workshops and recipes
+  const { data: workshops = [] } = useQuery({
+    queryKey: ["workshops"],
+    queryFn: gameApi.workshops,
+  })
+  const { data: craftingRecipes = [] } = useQuery({
+    queryKey: ["craftingRecipes"],
+    queryFn: () => gameApi.craftingRecipes("limit=10000"),
+  })
+  const { data: materialRecipes = [] } = useQuery({
+    queryKey: ["materialRecipes"],
+    queryFn: () => gameApi.materialRecipes("limit=10000"),
+  })
+
+  // Build recipe index
+  const recipeIndex = useMemo<RecipeIndex | null>(
+    () =>
+      craftingRecipes.length > 0 && materialRecipes.length > 0
+        ? buildRecipeIndex(craftingRecipes, materialRecipes)
+        : null,
+    [craftingRecipes, materialRecipes]
+  )
+
+  // Convert inventory to craftable items
+  const craftables = useMemo(() => {
+    const all = inventoryToCraftables(items, blades, armor)
+    if (includeEquipped) return all
+    return all.filter((c) => !c.sourceItem?.equip_slot)
+  }, [items, blades, armor, includeEquipped])
+
+  // ── Forward mode: picker items + search ────────────────────────────
+
+  const bladePickerItems: PickerItem[] = useMemo(
+    () =>
+      blades.map((b) => ({
+        name: b.name,
+        type: b.blade_type,
+        level: b.game_id,
+        suffix: b.hands,
+      })),
+    [blades]
+  )
+
+  const armorPickerItems: PickerItem[] = useMemo(
+    () =>
+      armor.map((a) => ({
+        name: a.name,
+        type: a.armor_type,
+        level: a.game_id,
+      })),
+    [armor]
+  )
+
+  const allPickerItems = useMemo(
+    () => [...bladePickerItems, ...armorPickerItems],
+    [bladePickerItems, armorPickerItems]
+  )
+
+  // Determine available materials for target
+  const targetMaterials = useMemo(() => {
+    if (!targetItem) return []
+    const blade = blades.find((b) => b.name === targetItem)
+    if (blade) return BLADE_MATS
+    const a = armor.find((ar) => ar.name === targetItem)
+    if (a?.armor_type === "Shield")
+      return ["Wood", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+    if (a?.armor_type === "Accessory") return []
+    if (a) return ["Leather", "Bronze", "Iron", "Hagane", "Silver", "Damascus"]
+    return ALL_MATERIALS
+  }, [targetItem, blades, armor])
+
+  // Forward search results
+  const forwardPaths = useMemo<CraftingPath[]>(() => {
+    if (!recipeIndex || !targetItem || mode !== "forward") return []
+    return findCraftingPaths(
+      { name: targetItem, material: targetMaterial },
+      craftables,
+      recipeIndex,
+      { maxDepth: 4, maxResults: 20 }
+    )
+  }, [recipeIndex, targetItem, targetMaterial, craftables, mode])
+
+  // ── Reverse mode: source selection + search ────────────────────────
+
+  const reverseSource = useMemo(
+    () => craftables.find((c) => c.id === reverseSourceId) ?? null,
+    [craftables, reverseSourceId]
+  )
+
+  const reverseResults = useMemo<ReachableItem[]>(() => {
+    if (!recipeIndex || !reverseSource || mode !== "reverse") return []
+    return findReachableItems(reverseSource, craftables, recipeIndex, {
+      maxDepth: 3,
+      maxResults: 50,
+    })
+  }, [recipeIndex, reverseSource, craftables, mode])
+
+  // ── Render ─────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-4">
+      {/* Controls row */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Workshop selector */}
+        <Select value={workshopId} onValueChange={setWorkshopId}>
+          <SelectTrigger className="h-9 w-auto min-w-[12rem]">
+            <Settings2 className="mr-1.5 size-3.5" />
+            <SelectValue placeholder="Workshop" />
+          </SelectTrigger>
+          <SelectContent>
+            {workshops.map((w) => (
+              <SelectItem key={w.id} value={String(w.id)}>
+                <div>
+                  <div className="font-medium">{w.name}</div>
+                  <div className="text-muted-foreground text-xs">
+                    {w.available_materials}
+                  </div>
+                </div>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Mode toggle */}
+        <div className="flex rounded-lg border">
+          <button
+            type="button"
+            onClick={() => setMode("forward")}
+            className={cn(
+              "px-3 py-1.5 text-xs font-medium transition-colors",
+              mode === "forward"
+                ? "bg-primary text-primary-foreground rounded-l-lg"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Forward
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("reverse")}
+            className={cn(
+              "px-3 py-1.5 text-xs font-medium transition-colors",
+              mode === "reverse"
+                ? "bg-primary text-primary-foreground rounded-r-lg"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Reverse
+          </button>
+        </div>
+
+        {/* Include equipped toggle */}
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={includeEquipped}
+            onChange={(e) => setIncludeEquipped(e.target.checked)}
+            className="accent-primary size-3.5"
+          />
+          <span className="text-muted-foreground">Include equipped</span>
+        </label>
+      </div>
+
+      {/* Forward mode */}
+      {mode === "forward" && (
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-[14rem] flex-1">
+              <ItemPicker
+                items={allPickerItems}
+                value={targetItem}
+                onSelect={(name) => {
+                  setTargetItem(name)
+                  setTargetMaterial(null)
+                }}
+                placeholder="Select target item..."
+                label="Target"
+              />
+            </div>
+            {targetItem && targetMaterials.length > 0 && (
+              <div className="min-w-[10rem]">
+                <MaterialSelect
+                  materials={targetMaterials}
+                  value={targetMaterial}
+                  onSelect={setTargetMaterial}
+                  label="Material (optional)"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Results */}
+          {targetItem && recipeIndex && (
+            <ForwardResults
+              paths={forwardPaths}
+              targetName={targetItem}
+              targetMaterial={targetMaterial}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Reverse mode */}
+      {mode === "reverse" && (
+        <div className="space-y-4">
+          <div>
+            <label className="text-muted-foreground mb-1 block text-xs font-medium">
+              Select an item from your inventory
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {craftables.map((c) => (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => setReverseSourceId(c.id)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-lg border px-2 py-1.5 text-xs transition-colors",
+                    reverseSourceId === c.id
+                      ? "border-primary bg-primary/10"
+                      : "border-border/50 hover:border-foreground/30"
+                  )}
+                >
+                  <ItemIcon type={c.equipType} size="sm" />
+                  <span className="font-medium">{c.name}</span>
+                  {c.material && <MaterialBadge mat={c.material} />}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {reverseSource && recipeIndex && (
+            <ReverseResults
+              results={reverseResults}
+              sourceName={reverseSource.name}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!recipeIndex && (
+        <p className="text-muted-foreground py-8 text-center text-sm">
+          Loading crafting recipes...
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── Forward results ──────────────────────────────────────────────────
+
+function ForwardResults({
+  paths,
+  targetName,
+  targetMaterial,
+}: {
+  paths: CraftingPath[]
+  targetName: string
+  targetMaterial: string | null
+}) {
+  if (paths.length === 0) {
+    return (
+      <div className="text-muted-foreground py-6 text-center text-sm">
+        <FlaskConical className="mx-auto mb-2 size-8 opacity-30" />
+        <p>
+          No crafting paths found for{" "}
+          <span className="font-medium">{targetName}</span>
+          {targetMaterial && (
+            <>
+              {" "}
+              in <span className="font-medium">{targetMaterial}</span>
+            </>
+          )}
+        </p>
+        <p className="mt-1 text-xs">
+          Try a different material, or check that your inventory has compatible
+          items
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-xs">
+        {paths.length} path{paths.length !== 1 ? "s" : ""} found
+      </p>
+      {paths.map((path, i) => (
+        <PathCard key={i} path={path} rank={i + 1} />
+      ))}
+    </div>
+  )
+}
+
+function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
+  const [expanded, setExpanded] = useState(rank === 1)
+
+  return (
+    <Card
+      className={cn(
+        "cursor-pointer transition-colors",
+        rank === 1 && "border-primary/30"
+      )}
+      onClick={() => setExpanded(!expanded)}
+    >
+      <CardContent className="p-3">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <span className="text-muted-foreground font-mono text-xs">
+            #{rank}
+          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">{path.result.name}</span>
+            {path.result.material && (
+              <MaterialBadge mat={path.result.material} />
+            )}
+          </div>
+          <span className="text-muted-foreground ml-auto text-xs">
+            {path.steps.length} step{path.steps.length !== 1 ? "s" : ""}
+          </span>
+          <ChevronRight
+            className={cn(
+              "text-muted-foreground size-4 transition-transform",
+              expanded && "rotate-90"
+            )}
+          />
+        </div>
+
+        {/* Steps */}
+        {expanded && (
+          <div className="mt-3 space-y-2">
+            {path.steps.map((step, i) => (
+              <div
+                key={i}
+                className="bg-muted/30 flex items-center gap-2 rounded-lg px-3 py-2 text-xs"
+              >
+                <span className="text-muted-foreground font-mono">
+                  {i + 1}.
+                </span>
+                <div className="flex items-center gap-1">
+                  <ItemIcon type={step.input1.equipType} size="sm" />
+                  <span className="font-medium">{step.input1.name}</span>
+                  {step.input1.material && (
+                    <MaterialBadge mat={step.input1.material} />
+                  )}
+                </div>
+                <span className="text-muted-foreground">+</span>
+                <div className="flex items-center gap-1">
+                  <ItemIcon type={step.input2.equipType} size="sm" />
+                  <span className="font-medium">{step.input2.name}</span>
+                  {step.input2.material && (
+                    <MaterialBadge mat={step.input2.material} />
+                  )}
+                </div>
+                <ChevronRight className="text-muted-foreground size-3" />
+                <div className="flex items-center gap-1">
+                  <span className="text-primary font-medium">
+                    {step.result.name}
+                  </span>
+                  {step.result.material && (
+                    <MaterialBadge mat={step.result.material} />
+                  )}
+                </div>
+              </div>
+            ))}
+
+            {/* Consumed items summary */}
+            <div className="text-muted-foreground pt-1 text-[11px]">
+              Consumes:{" "}
+              {path.consumedItems
+                .filter((c) => c.sourceItem)
+                .map((c) => `${c.name} (${c.material})`)
+                .join(", ") || "intermediate results only"}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ── Reverse results ──────────────────────────────────────────────────
+
+function ReverseResults({
+  results,
+  sourceName,
+}: {
+  results: ReachableItem[]
+  sourceName: string
+}) {
+  if (results.length === 0) {
+    return (
+      <div className="text-muted-foreground py-6 text-center text-sm">
+        <Undo2 className="mx-auto mb-2 size-8 opacity-30" />
+        <p>
+          No crafting options found for{" "}
+          <span className="font-medium">{sourceName}</span>
+        </p>
+        <p className="mt-1 text-xs">
+          This item can't be combined with anything in your current inventory
+        </p>
+      </div>
+    )
+  }
+
+  // Group by depth
+  const byDepth = new Map<number, ReachableItem[]>()
+  for (const r of results) {
+    const list = byDepth.get(r.depth) ?? []
+    list.push(r)
+    byDepth.set(r.depth, list)
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-xs">
+        {results.length} reachable item{results.length !== 1 ? "s" : ""} from{" "}
+        <span className="font-medium">{sourceName}</span>
+      </p>
+
+      {[...byDepth.entries()].map(([depth, items]) => (
+        <div key={depth}>
+          <p className="text-muted-foreground mb-2 text-xs font-medium">
+            {depth} step{depth !== 1 ? "s" : ""}
+          </p>
+          <div className="space-y-1">
+            {items.map((r, i) => (
+              <div
+                key={i}
+                className="border-border/50 flex items-center gap-2 rounded-lg border px-3 py-2"
+              >
+                <ItemIcon type={r.item.equipType} size="sm" />
+                <span className="text-sm font-medium">{r.item.name}</span>
+                {r.item.material && <MaterialBadge mat={r.item.material} />}
+                <span className="text-muted-foreground ml-auto text-xs">
+                  {r.path
+                    .map(
+                      (s) =>
+                        `${s.input1.name} + ${s.input2.name} → ${s.result.name}`
+                    )
+                    .join(" → ")}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -61,6 +61,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
   const [workshopId, setWorkshopId] = useState<string>("6")
   const [includeEquipped, setIncludeEquipped] = useState(true)
   const [forwardCategory, setForwardCategory] = useState<Category>("blade")
+  const [forwardDepth, setForwardDepth] = useState<number>(1)
 
   // Reverse mode state
   const [targetItem, setTargetItem] = useState<string | null>(null)
@@ -140,6 +141,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
       craftingRecipes: filteredRecipes,
       materialRecipes,
       craftables: filtered,
+      maxDepth: forwardDepth,
     })
   }
 
@@ -291,6 +293,21 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 <SelectItem value="blade">Blades</SelectItem>
                 <SelectItem value="shield">Shields</SelectItem>
                 <SelectItem value="armor">Armor</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={String(forwardDepth)}
+              onValueChange={(v) => {
+                setForwardDepth(Number(v))
+                setDiscoverSearched(false)
+              }}
+            >
+              <SelectTrigger className="h-9 w-auto min-w-[6rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">1 step</SelectItem>
+                <SelectItem value="2">2 steps</SelectItem>
               </SelectContent>
             </Select>
             <Button
@@ -548,14 +565,6 @@ function PathCard({ path, rank }: { path: CraftingPath; rank: number }) {
                 </div>
               </div>
             ))}
-
-            <div className="text-muted-foreground pt-1 text-[11px]">
-              Consumes:{" "}
-              {path.consumedItems
-                .filter((c) => c.sourceItem)
-                .map((c) => `${c.name} (${c.material})`)
-                .join(", ") || "intermediate results only"}
-            </div>
           </div>
         )}
       </CardContent>

--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   ChevronRight,
   FlaskConical,
+  Loader2,
   Search,
   Settings2,
   Undo2,
@@ -23,14 +24,11 @@ import { MaterialSelect } from "@/components/material-select"
 import { gameApi, type Armor, type Blade } from "@/lib/game-api"
 import type { InventoryItem } from "@/lib/inventory-api"
 import {
-  buildRecipeIndex,
-  findCraftingPaths,
-  findReachableItems,
   inventoryToCraftables,
   type CraftingPath,
   type ReachableItem,
-  type RecipeIndex,
 } from "@/lib/crafting-optimizer"
+import type { WorkerRequest, WorkerResponse } from "@/lib/crafting-worker"
 import { cn } from "@/lib/utils"
 
 // ── Materials available per workshop ─────────────────────────────────
@@ -80,14 +78,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     queryFn: () => gameApi.materialRecipes("limit=10000"),
   })
 
-  // Build recipe index
-  const recipeIndex = useMemo<RecipeIndex | null>(
-    () =>
-      craftingRecipes.length > 0 && materialRecipes.length > 0
-        ? buildRecipeIndex(craftingRecipes, materialRecipes)
-        : null,
-    [craftingRecipes, materialRecipes]
-  )
+  const recipesReady = craftingRecipes.length > 0 && materialRecipes.length > 0
 
   // Convert inventory to craftable items
   const craftables = useMemo(() => {
@@ -95,6 +86,44 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     if (includeEquipped) return all
     return all.filter((c) => !c.sourceItem?.equip_slot)
   }, [items, blades, armor, includeEquipped])
+
+  // ── Search state (declared before worker so refs can access them) ──
+
+  const [forwardPaths, setForwardPaths] = useState<CraftingPath[]>([])
+  const [forwardSearched, setForwardSearched] = useState(false)
+  const [reverseResults, setReverseResults] = useState<ReachableItem[]>([])
+  const [reverseSearched, setReverseSearched] = useState(false)
+
+  // ── Web Worker ─────────────────────────────────────────────────────
+
+  const workerRef = useRef<Worker | null>(null)
+  const [searching, setSearching] = useState(false)
+
+  useEffect(() => {
+    const worker = new Worker(
+      new URL("@/lib/crafting-worker.ts", import.meta.url),
+      { type: "module" }
+    )
+    worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+      const res = e.data
+      setSearching(false)
+      if (res.type === "forward" && res.forwardPaths) {
+        setForwardPaths(res.forwardPaths)
+        setForwardSearched(true)
+      } else if (res.type === "reverse" && res.reverseResults) {
+        setReverseResults(res.reverseResults)
+        setReverseSearched(true)
+      }
+    }
+    workerRef.current = worker
+    return () => worker.terminate()
+  }, [])
+
+  const postWorker = useCallback((req: WorkerRequest) => {
+    if (!workerRef.current) return
+    setSearching(true)
+    workerRef.current.postMessage(req)
+  }, [])
 
   // ── Forward mode: picker items + search ────────────────────────────
 
@@ -137,21 +166,18 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     return ALL_MATERIALS
   }, [targetItem, blades, armor])
 
-  // Forward search — triggered by button click
-  const [forwardPaths, setForwardPaths] = useState<CraftingPath[]>([])
-  const [forwardSearched, setForwardSearched] = useState(false)
-
+  // Forward search — triggered by button click, runs in worker
   const runForwardSearch = () => {
-    if (!recipeIndex || !targetItem) return
-    setForwardSearched(true)
-    setForwardPaths(
-      findCraftingPaths(
-        { name: targetItem, material: targetMaterial },
-        craftables,
-        recipeIndex,
-        { maxDepth: 3, maxResults: 20, maxStates: 5000 }
-      )
-    )
+    if (!recipesReady || !targetItem) return
+    setForwardSearched(false)
+    postWorker({
+      type: "forward",
+      craftingRecipes,
+      materialRecipes,
+      craftables,
+      targetName: targetItem,
+      targetMaterial,
+    })
   }
 
   // ── Reverse mode: source selection + search ────────────────────────
@@ -161,19 +187,16 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
     [craftables, reverseSourceId]
   )
 
-  const [reverseResults, setReverseResults] = useState<ReachableItem[]>([])
-  const [reverseSearched, setReverseSearched] = useState(false)
-
   const runReverseSearch = () => {
-    if (!recipeIndex || !reverseSource) return
-    setReverseSearched(true)
-    setReverseResults(
-      findReachableItems(reverseSource, craftables, recipeIndex, {
-        maxDepth: 2,
-        maxResults: 50,
-        maxStates: 5000,
-      })
-    )
+    if (!recipesReady || !reverseSource) return
+    setReverseSearched(false)
+    postWorker({
+      type: "reverse",
+      craftingRecipes,
+      materialRecipes,
+      craftables,
+      sourceItem: reverseSource,
+    })
   }
 
   // ── Render ─────────────────────────────────────────────────────────
@@ -272,10 +295,14 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
                 />
               </div>
             )}
-            {targetItem && recipeIndex && (
-              <Button onClick={runForwardSearch} size="sm">
-                <Search className="size-3.5" />
-                Find Paths
+            {targetItem && recipesReady && (
+              <Button onClick={runForwardSearch} size="sm" disabled={searching}>
+                {searching ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <Search className="size-3.5" />
+                )}
+                {searching ? "Searching..." : "Find Paths"}
               </Button>
             )}
           </div>
@@ -322,10 +349,14 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
             </div>
           </div>
 
-          {reverseSource && recipeIndex && (
-            <Button onClick={runReverseSearch} size="sm">
-              <Search className="size-3.5" />
-              Find Craftable Items
+          {reverseSource && recipesReady && (
+            <Button onClick={runReverseSearch} size="sm" disabled={searching}>
+              {searching ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Search className="size-3.5" />
+              )}
+              {searching ? "Searching..." : "Find Craftable Items"}
             </Button>
           )}
 
@@ -339,7 +370,7 @@ export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
       )}
 
       {/* Empty state */}
-      {!recipeIndex && (
+      {!recipesReady && (
         <p className="text-muted-foreground py-8 text-center text-sm">
           Loading crafting recipes...
         </p>

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -18,6 +18,7 @@ import {
   ArrowLeft,
   ArrowLeftFromLine,
   ArrowRightFromLine,
+  Hammer,
   Package,
   Plus,
   Search,
@@ -72,6 +73,7 @@ import {
   DISPLAY_TYPE_TO_CATEGORY,
   type SlotConfig,
 } from "@/lib/inventory-constants"
+import { CraftingTab } from "@/pages/inventory/crafting-tab"
 import { cn } from "@/lib/utils"
 
 // ── Slot configuration ──────────────────────────────────────────────
@@ -136,6 +138,9 @@ type BagSort = "equipped" | "added" | "name"
 
 function InventoryDetail({ inventoryId }: { inventoryId: number }) {
   const queryClient = useQueryClient()
+  const [activeTab, setActiveTab] = useState<"equipment" | "crafting">(
+    "equipment"
+  )
   const [editingSlot, setEditingSlot] = useState<SlotConfig | null>(null)
   const [editingBagItem, setEditingBagItem] = useState(false)
   const [bagSearch, setBagSearch] = useState("")
@@ -811,325 +816,378 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
         <h2 className="text-lg font-medium">{inventory.name}</h2>
       </div>
 
-      <DndContext
-        sensors={sensors}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-      >
-        {/* Shared filter controls for bag + container */}
-        {allItems.length > 1 && (
-          <div className="flex items-center gap-2">
-            {itemCategories.length > 1 && (
-              <Select value={bagCategory} onValueChange={setBagCategory}>
-                <SelectTrigger className="h-9 w-auto min-w-[7rem] shrink-0">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All ({allItems.length})</SelectItem>
-                  {itemCategories.map((c) => {
-                    const limitKey = ARMOR_POOL_TYPES.has(c.label)
-                      ? "Armor"
-                      : c.label
-                    const total =
-                      (BAG_LIMITS[limitKey] ?? 0) +
-                      (CONTAINER_LIMITS[limitKey] ?? 0)
-                    return (
-                      <SelectItem key={c.label} value={c.label}>
-                        {c.label} ({c.count}
-                        {total > 0 ? `/${total}` : ""})
-                      </SelectItem>
-                    )
-                  })}
-                </SelectContent>
-              </Select>
-            )}
-            <div className="relative flex-1">
-              <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-              <Input
-                value={bagSearch}
-                onChange={(e) => setBagSearch(e.target.value)}
-                placeholder="Filter items..."
-                className="pr-8 pl-9"
-              />
-              {bagSearch && (
-                <button
-                  type="button"
-                  onClick={() => setBagSearch("")}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
-                >
-                  <X className="size-4" />
-                </button>
-              )}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="shrink-0"
-              onClick={() =>
-                setBagSort((s) =>
-                  s === "equipped"
-                    ? "added"
-                    : s === "added"
-                      ? "name"
-                      : "equipped"
-                )
-              }
-            >
-              {bagSort === "name" ? (
-                <ArrowDownAZ className="size-3.5" />
-              ) : (
-                <ArrowDownWideNarrow className="size-3.5" />
-              )}
-              {bagSort === "equipped"
-                ? "Equipped"
-                : bagSort === "added"
-                  ? "Added"
-                  : "Name"}
-            </Button>
-          </div>
-        )}
-
-        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1.2fr)]">
-          {/* Left Column: Equipment + Stats */}
-          <div className="space-y-6">
-            {/* Equipment Grid */}
-            <div className="mx-auto max-w-sm lg:max-w-none">
-              <EquipmentGridDropZone
-                isOver={
-                  activeDragItem !== null &&
-                  activeDragItem.equip_slot === null &&
-                  getEquipSlotForItem(activeDragItem) !== null
-                }
-              >
-                <EquipmentGrid
-                  getSlotItem={getSlotItem}
-                  getItemDisplayName={getItemDisplayName}
-                  getItemDisplayType={getItemDisplayType}
-                  onSlotClick={setEditingSlot}
-                  onUnequip={(slotItem) =>
-                    updateItemMutation.mutate({
-                      itemId: slotItem.id,
-                      equip_slot: null,
-                    })
-                  }
-                  equippedBladeIs2H={equippedBladeIs2H}
-                />
-              </EquipmentGridDropZone>
-            </div>
-
-            {/* Combined Stats */}
-            {combinedStats &&
-              inventory.items.some((i) => i.equip_slot != null) && (
-                <CombinedStatsCard stats={combinedStats} />
-              )}
-          </div>
-
-          {/* Middle Column: Item Bag */}
-          <BagDropZone
-            isOver={
-              activeDragItem !== null &&
-              (activeDragItem.equip_slot !== null ||
-                activeDragItem.storage === "container")
-            }
-          >
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium">
-                  <Package className="mr-1.5 inline size-4" />
-                  Item Bag ({filteredBagItems.length})
-                  {sectionLimits?.bag && (
-                    <span className="text-muted-foreground ml-2 text-sm font-normal">
-                      {sectionLimits.bag}
-                    </span>
-                  )}
-                </h3>
-                <Button size="sm" onClick={() => setEditingBagItem(true)}>
-                  <Plus className="size-3.5" />
-                  Add Item
-                </Button>
-              </div>
-              {bagItems.length === 0 ? (
-                <p className="text-muted-foreground py-4 text-center text-xs">
-                  No items in the bag
-                </p>
-              ) : filteredBagItems.length === 0 ? (
-                <p className="text-muted-foreground py-4 text-center text-xs">
-                  No items match
-                  {bagCategory !== "all" && ` "${bagCategory}"`}
-                  {bagSearch && ` "${bagSearch}"`}
-                </p>
-              ) : (
-                <div className="max-h-[60vh] space-y-1 overflow-y-auto">
-                  {filteredBagItems.map((item) => {
-                    const targetSlot = !item.equip_slot
-                      ? getEquipSlotForItem(item)
-                      : null
-                    return (
-                      <DraggableBagItemRow
-                        key={item.id}
-                        item={item}
-                        name={getItemDisplayName(item)}
-                        type={getItemDisplayType(item)}
-                        isDraggable
-                        isDragging={activeDragItem?.id === item.id}
-                        onDelete={() => deleteItemMutation.mutate(item.id)}
-                        onUnequip={
-                          item.equip_slot
-                            ? () =>
-                                updateItemMutation.mutate({
-                                  itemId: item.id,
-                                  equip_slot: null,
-                                })
-                            : undefined
-                        }
-                        onEquip={
-                          targetSlot
-                            ? () => equipToSlot(item, targetSlot)
-                            : undefined
-                        }
-                        onMoveToContainer={
-                          !item.equip_slot
-                            ? () =>
-                                updateItemMutation.mutate({
-                                  itemId: item.id,
-                                  storage: "container",
-                                })
-                            : undefined
-                        }
-                      />
-                    )
-                  })}
-                </div>
-              )}
-            </div>
-          </BagDropZone>
-
-          {/* Right Column: Container */}
-          <ContainerDropZone
-            isOver={
-              activeDragItem !== null &&
-              activeDragItem.storage !== "container" &&
-              !activeDragItem.equip_slot
-            }
-          >
-            <div className="space-y-3">
-              <h3 className="font-medium">
-                <Package className="mr-1.5 inline size-4" />
-                Container ({filteredContainerItems.length})
-                {sectionLimits?.container && (
-                  <span className="text-muted-foreground ml-2 text-sm font-normal">
-                    {sectionLimits.container}
-                  </span>
-                )}
-              </h3>
-              {containerItems.length === 0 ? (
-                <p className="text-muted-foreground py-4 text-center text-xs">
-                  Drop items here to store them
-                </p>
-              ) : filteredContainerItems.length === 0 ? (
-                <p className="text-muted-foreground py-4 text-center text-xs">
-                  No items match filter
-                </p>
-              ) : (
-                <div className="max-h-[60vh] space-y-1 overflow-y-auto">
-                  {filteredContainerItems.map((item) => (
-                    <DraggableBagItemRow
-                      key={item.id}
-                      item={item}
-                      name={getItemDisplayName(item)}
-                      type={getItemDisplayType(item)}
-                      isDraggable
-                      isDragging={activeDragItem?.id === item.id}
-                      onDelete={() => deleteItemMutation.mutate(item.id)}
-                      onMoveToBag={() =>
-                        updateItemMutation.mutate({
-                          itemId: item.id,
-                          storage: "bag",
-                        })
-                      }
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          </ContainerDropZone>
-        </div>
-
-        <DragOverlay dropAnimation={null}>
-          {activeDragItem && (
-            <div className="bg-card border-primary/50 rounded-lg border px-3 py-2 shadow-lg">
-              <div className="flex items-center gap-2">
-                <ItemIcon type={getItemDisplayType(activeDragItem)} size="sm" />
-                <span className="text-sm font-medium">
-                  {getItemDisplayName(activeDragItem)}
-                </span>
-              </div>
-            </div>
+      {/* Tabs */}
+      <div className="border-border/50 flex gap-0 border-b">
+        <button
+          type="button"
+          onClick={() => setActiveTab("equipment")}
+          className={cn(
+            "relative flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors",
+            activeTab === "equipment"
+              ? "text-foreground"
+              : "text-muted-foreground hover:text-foreground"
           )}
-        </DragOverlay>
-      </DndContext>
+        >
+          <Package className="size-4" />
+          Equipment
+          {activeTab === "equipment" && (
+            <span className="bg-primary absolute bottom-0 left-0 h-0.5 w-full rounded-full" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("crafting")}
+          className={cn(
+            "relative flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors",
+            activeTab === "crafting"
+              ? "text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <Hammer className="size-4" />
+          Crafting
+          {activeTab === "crafting" && (
+            <span className="bg-primary absolute bottom-0 left-0 h-0.5 w-full rounded-full" />
+          )}
+        </button>
+      </div>
 
-      {/* Slot Editor Dialog */}
-      {editingSlot && (
-        <SlotEditorDialog
-          slot={editingSlot}
-          existingItem={getSlotItem(editingSlot.key)}
-          blades={blades}
-          armor={armor}
-          grips={grips}
-          gems={gems}
-          consumables={consumables}
-          bladeMap={bladeMap}
-          bladeIdMap={bladeIdMap}
-          armorMap={armorMap}
-          armorIdMap={armorIdMap}
-          gripMap={gripMap}
-          gripIdMap={gripIdMap}
-          gemMap={gemMap}
-          gemIdMap={gemIdMap}
-          consumableMap={consumableMap}
-          consumableIdMap={consumableIdMap}
-          onSave={handleSlotSave}
-          onUnequip={
-            getSlotItem(editingSlot.key)
-              ? () => {
-                  const item = getSlotItem(editingSlot.key)!
-                  updateItemMutation.mutate(
-                    { itemId: item.id, equip_slot: null },
-                    { onSuccess: () => setEditingSlot(null) }
-                  )
-                }
-              : undefined
-          }
-          onClose={() => setEditingSlot(null)}
-          isPending={addItemMutation.isPending || updateItemMutation.isPending}
-        />
+      {/* Crafting Tab */}
+      {activeTab === "crafting" && (
+        <CraftingTab items={allItems} blades={blades} armor={armor} />
       )}
 
-      {/* Bag Item Editor Dialog */}
-      {editingBagItem && (
-        <SlotEditorDialog
-          slot={null}
-          existingItem={undefined}
-          blades={blades}
-          armor={armor}
-          grips={grips}
-          gems={gems}
-          consumables={consumables}
-          bladeMap={bladeMap}
-          bladeIdMap={bladeIdMap}
-          armorMap={armorMap}
-          armorIdMap={armorIdMap}
-          gripMap={gripMap}
-          gripIdMap={gripIdMap}
-          gemMap={gemMap}
-          gemIdMap={gemIdMap}
-          consumableMap={consumableMap}
-          consumableIdMap={consumableIdMap}
-          onSave={handleBagSave}
-          onClose={() => setEditingBagItem(false)}
-          isPending={addItemMutation.isPending}
-        />
+      {/* Equipment Tab */}
+      {activeTab === "equipment" && (
+        <>
+          <DndContext
+            sensors={sensors}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            {/* Shared filter controls for bag + container */}
+            {allItems.length > 1 && (
+              <div className="flex items-center gap-2">
+                {itemCategories.length > 1 && (
+                  <Select value={bagCategory} onValueChange={setBagCategory}>
+                    <SelectTrigger className="h-9 w-auto min-w-[7rem] shrink-0">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">
+                        All ({allItems.length})
+                      </SelectItem>
+                      {itemCategories.map((c) => {
+                        const limitKey = ARMOR_POOL_TYPES.has(c.label)
+                          ? "Armor"
+                          : c.label
+                        const total =
+                          (BAG_LIMITS[limitKey] ?? 0) +
+                          (CONTAINER_LIMITS[limitKey] ?? 0)
+                        return (
+                          <SelectItem key={c.label} value={c.label}>
+                            {c.label} ({c.count}
+                            {total > 0 ? `/${total}` : ""})
+                          </SelectItem>
+                        )
+                      })}
+                    </SelectContent>
+                  </Select>
+                )}
+                <div className="relative flex-1">
+                  <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+                  <Input
+                    value={bagSearch}
+                    onChange={(e) => setBagSearch(e.target.value)}
+                    placeholder="Filter items..."
+                    className="pr-8 pl-9"
+                  />
+                  {bagSearch && (
+                    <button
+                      type="button"
+                      onClick={() => setBagSearch("")}
+                      className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+                    >
+                      <X className="size-4" />
+                    </button>
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() =>
+                    setBagSort((s) =>
+                      s === "equipped"
+                        ? "added"
+                        : s === "added"
+                          ? "name"
+                          : "equipped"
+                    )
+                  }
+                >
+                  {bagSort === "name" ? (
+                    <ArrowDownAZ className="size-3.5" />
+                  ) : (
+                    <ArrowDownWideNarrow className="size-3.5" />
+                  )}
+                  {bagSort === "equipped"
+                    ? "Equipped"
+                    : bagSort === "added"
+                      ? "Added"
+                      : "Name"}
+                </Button>
+              </div>
+            )}
+
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1.2fr)]">
+              {/* Left Column: Equipment + Stats */}
+              <div className="space-y-6">
+                {/* Equipment Grid */}
+                <div className="mx-auto max-w-sm lg:max-w-none">
+                  <EquipmentGridDropZone
+                    isOver={
+                      activeDragItem !== null &&
+                      activeDragItem.equip_slot === null &&
+                      getEquipSlotForItem(activeDragItem) !== null
+                    }
+                  >
+                    <EquipmentGrid
+                      getSlotItem={getSlotItem}
+                      getItemDisplayName={getItemDisplayName}
+                      getItemDisplayType={getItemDisplayType}
+                      onSlotClick={setEditingSlot}
+                      onUnequip={(slotItem) =>
+                        updateItemMutation.mutate({
+                          itemId: slotItem.id,
+                          equip_slot: null,
+                        })
+                      }
+                      equippedBladeIs2H={equippedBladeIs2H}
+                    />
+                  </EquipmentGridDropZone>
+                </div>
+
+                {/* Combined Stats */}
+                {combinedStats &&
+                  inventory.items.some((i) => i.equip_slot != null) && (
+                    <CombinedStatsCard stats={combinedStats} />
+                  )}
+              </div>
+
+              {/* Middle Column: Item Bag */}
+              <BagDropZone
+                isOver={
+                  activeDragItem !== null &&
+                  (activeDragItem.equip_slot !== null ||
+                    activeDragItem.storage === "container")
+                }
+              >
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-medium">
+                      <Package className="mr-1.5 inline size-4" />
+                      Item Bag ({filteredBagItems.length})
+                      {sectionLimits?.bag && (
+                        <span className="text-muted-foreground ml-2 text-sm font-normal">
+                          {sectionLimits.bag}
+                        </span>
+                      )}
+                    </h3>
+                    <Button size="sm" onClick={() => setEditingBagItem(true)}>
+                      <Plus className="size-3.5" />
+                      Add Item
+                    </Button>
+                  </div>
+                  {bagItems.length === 0 ? (
+                    <p className="text-muted-foreground py-4 text-center text-xs">
+                      No items in the bag
+                    </p>
+                  ) : filteredBagItems.length === 0 ? (
+                    <p className="text-muted-foreground py-4 text-center text-xs">
+                      No items match
+                      {bagCategory !== "all" && ` "${bagCategory}"`}
+                      {bagSearch && ` "${bagSearch}"`}
+                    </p>
+                  ) : (
+                    <div className="max-h-[60vh] space-y-1 overflow-y-auto">
+                      {filteredBagItems.map((item) => {
+                        const targetSlot = !item.equip_slot
+                          ? getEquipSlotForItem(item)
+                          : null
+                        return (
+                          <DraggableBagItemRow
+                            key={item.id}
+                            item={item}
+                            name={getItemDisplayName(item)}
+                            type={getItemDisplayType(item)}
+                            isDraggable
+                            isDragging={activeDragItem?.id === item.id}
+                            onDelete={() => deleteItemMutation.mutate(item.id)}
+                            onUnequip={
+                              item.equip_slot
+                                ? () =>
+                                    updateItemMutation.mutate({
+                                      itemId: item.id,
+                                      equip_slot: null,
+                                    })
+                                : undefined
+                            }
+                            onEquip={
+                              targetSlot
+                                ? () => equipToSlot(item, targetSlot)
+                                : undefined
+                            }
+                            onMoveToContainer={
+                              !item.equip_slot
+                                ? () =>
+                                    updateItemMutation.mutate({
+                                      itemId: item.id,
+                                      storage: "container",
+                                    })
+                                : undefined
+                            }
+                          />
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              </BagDropZone>
+
+              {/* Right Column: Container */}
+              <ContainerDropZone
+                isOver={
+                  activeDragItem !== null &&
+                  activeDragItem.storage !== "container" &&
+                  !activeDragItem.equip_slot
+                }
+              >
+                <div className="space-y-3">
+                  <h3 className="font-medium">
+                    <Package className="mr-1.5 inline size-4" />
+                    Container ({filteredContainerItems.length})
+                    {sectionLimits?.container && (
+                      <span className="text-muted-foreground ml-2 text-sm font-normal">
+                        {sectionLimits.container}
+                      </span>
+                    )}
+                  </h3>
+                  {containerItems.length === 0 ? (
+                    <p className="text-muted-foreground py-4 text-center text-xs">
+                      Drop items here to store them
+                    </p>
+                  ) : filteredContainerItems.length === 0 ? (
+                    <p className="text-muted-foreground py-4 text-center text-xs">
+                      No items match filter
+                    </p>
+                  ) : (
+                    <div className="max-h-[60vh] space-y-1 overflow-y-auto">
+                      {filteredContainerItems.map((item) => (
+                        <DraggableBagItemRow
+                          key={item.id}
+                          item={item}
+                          name={getItemDisplayName(item)}
+                          type={getItemDisplayType(item)}
+                          isDraggable
+                          isDragging={activeDragItem?.id === item.id}
+                          onDelete={() => deleteItemMutation.mutate(item.id)}
+                          onMoveToBag={() =>
+                            updateItemMutation.mutate({
+                              itemId: item.id,
+                              storage: "bag",
+                            })
+                          }
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </ContainerDropZone>
+            </div>
+
+            <DragOverlay dropAnimation={null}>
+              {activeDragItem && (
+                <div className="bg-card border-primary/50 rounded-lg border px-3 py-2 shadow-lg">
+                  <div className="flex items-center gap-2">
+                    <ItemIcon
+                      type={getItemDisplayType(activeDragItem)}
+                      size="sm"
+                    />
+                    <span className="text-sm font-medium">
+                      {getItemDisplayName(activeDragItem)}
+                    </span>
+                  </div>
+                </div>
+              )}
+            </DragOverlay>
+          </DndContext>
+
+          {/* Slot Editor Dialog */}
+          {editingSlot && (
+            <SlotEditorDialog
+              slot={editingSlot}
+              existingItem={getSlotItem(editingSlot.key)}
+              blades={blades}
+              armor={armor}
+              grips={grips}
+              gems={gems}
+              consumables={consumables}
+              bladeMap={bladeMap}
+              bladeIdMap={bladeIdMap}
+              armorMap={armorMap}
+              armorIdMap={armorIdMap}
+              gripMap={gripMap}
+              gripIdMap={gripIdMap}
+              gemMap={gemMap}
+              gemIdMap={gemIdMap}
+              consumableMap={consumableMap}
+              consumableIdMap={consumableIdMap}
+              onSave={handleSlotSave}
+              onUnequip={
+                getSlotItem(editingSlot.key)
+                  ? () => {
+                      const item = getSlotItem(editingSlot.key)!
+                      updateItemMutation.mutate(
+                        { itemId: item.id, equip_slot: null },
+                        { onSuccess: () => setEditingSlot(null) }
+                      )
+                    }
+                  : undefined
+              }
+              onClose={() => setEditingSlot(null)}
+              isPending={
+                addItemMutation.isPending || updateItemMutation.isPending
+              }
+            />
+          )}
+
+          {/* Bag Item Editor Dialog */}
+          {editingBagItem && (
+            <SlotEditorDialog
+              slot={null}
+              existingItem={undefined}
+              blades={blades}
+              armor={armor}
+              grips={grips}
+              gems={gems}
+              consumables={consumables}
+              bladeMap={bladeMap}
+              bladeIdMap={bladeIdMap}
+              armorMap={armorMap}
+              armorIdMap={armorIdMap}
+              gripMap={gripMap}
+              gripIdMap={gripIdMap}
+              gemMap={gemMap}
+              gemIdMap={gemIdMap}
+              consumableMap={consumableMap}
+              consumableIdMap={consumableIdMap}
+              onSave={handleBagSave}
+              onClose={() => setEditingBagItem(false)}
+              isPending={addItemMutation.isPending}
+            />
+          )}
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
Crafting optimizer for inventory detail page with forward discovery and reverse path finding.

**Algorithm:**
- BFS-based multi-step crafting path finder (Web Worker, no UI freeze)
- Forward discovery: find all upgrades craftable from current inventory
- Reverse search: find paths to a specific target item+material
- Material tracking through each step via material recipe lookup
- Stat comparison (STR/INT/AGI diffs) using category-specific material modifiers
- 15 unit tests

**UX:**
- Equipment/Crafting tabs on inventory detail page
- Forward mode: "What Can I Make?" — category + depth selector, auto-discovers upgrades
- Reverse mode: "How Do I Make...?" — target item + material picker
- Workshop selector, include-equipped checkbox, shared depth control
- MAT UPGRADE / TIER UP / stat diff badges on results
- Sort by: Best Overall, Material Tier, Stat Gain, Fewest Steps
- Filter by: All Upgrades, Material Upgrades, Tier Up, Stat Gains
- Expandable multi-step results, inline 1-step results
- Show more pagination (20 per page)

**Bug fixes:**
- Material IDs are 1-based in save files (0=none, fixes all materials being one tier too high)

## Test plan
- [x] Forward discovery returns results for blades/shields/armor
- [x] Results show correct material badges and stat diffs
- [x] Sort and filter controls work on cached results
- [x] 2-step depth shows multi-step paths with expand
- [x] Reverse search finds paths to target items
- [x] Web Worker keeps UI responsive during search
- [x] Material fix: re-imported save shows correct materials