### PR TITLE
Show drop locations on all item detail pages

### DIFF
--- a/src/components/item-drop-locations.tsx
+++ b/src/components/item-drop-locations.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Badge } from "@/components/ui/badge"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { MaterialBadge } from "@/components/stat-display"
+import { gameApi } from "@/lib/game-api"
+import { cn } from "@/lib/utils"
+
+const CHANCE_COLORS: Record<string, string> = {
+  always: "text-green-400",
+  excellent: "text-green-400",
+  "very good": "text-primary",
+  good: "text-primary",
+  fair: "text-foreground",
+  moderate: "text-foreground",
+  poor: "text-muted-foreground",
+  "very poor": "text-muted-foreground",
+  remote: "text-muted-foreground/50",
+  abysmal: "text-muted-foreground/50",
+}
+
+interface EnemyGroup {
+  enemy_name: string
+  enemy_id: number
+  enemy_class: string
+  locations: {
+    area_name: string
+    area_id: number
+    room_name: string
+    body_part: string
+    material: string
+    drop_chance: string
+    drop_value: number
+    grip: string
+    quantity: number
+    condition: string
+  }[]
+}
+
+export function ItemDropLocations({ itemName }: { itemName: string }) {
+  const { data: drops = [], isLoading } = useQuery({
+    queryKey: ["item-drops", itemName],
+    queryFn: () => gameApi.itemDrops(itemName),
+    enabled: !!itemName,
+  })
+
+  const grouped = useMemo(() => {
+    const map = new Map<number, EnemyGroup>()
+    for (const drop of drops) {
+      if (!map.has(drop.enemy_id)) {
+        map.set(drop.enemy_id, {
+          enemy_name: drop.enemy_name,
+          enemy_id: drop.enemy_id,
+          enemy_class: drop.enemy_class,
+          locations: [],
+        })
+      }
+      map.get(drop.enemy_id)!.locations.push({
+        area_name: drop.area_name,
+        area_id: drop.area_id,
+        room_name: drop.room_name,
+        body_part: drop.body_part,
+        material: drop.material,
+        drop_chance: drop.drop_chance,
+        drop_value: drop.drop_value,
+        grip: drop.grip,
+        quantity: drop.quantity,
+        condition: drop.condition,
+      })
+    }
+    return [...map.values()]
+  }, [drops])
+
+  if (isLoading) return null
+  if (drops.length === 0) return null
+
+  return (
+    <div className="mt-6">
+      <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
+        Where to Find
+      </p>
+      <div className="space-y-2">
+        {grouped.map((group) => (
+          <div
+            key={group.enemy_id}
+            className="bg-muted/30 rounded px-3 py-2 text-xs"
+          >
+            <div className="flex items-center gap-2">
+              <a
+                href={`/bestiary/${group.enemy_id}`}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary hover:text-primary/80 font-medium underline decoration-dotted underline-offset-2"
+              >
+                {group.enemy_name}
+              </a>
+              <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                {group.enemy_class}
+              </Badge>
+            </div>
+            <div className="mt-1.5 space-y-1">
+              {group.locations.map((loc, i) => (
+                <div
+                  key={`${loc.area_id}-${loc.room_name}-${loc.body_part}-${i}`}
+                  className="flex flex-wrap items-center gap-x-2 gap-y-0.5"
+                >
+                  <a
+                    href={`/areas/${loc.area_id}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary hover:text-primary/80 underline decoration-dotted underline-offset-2"
+                  >
+                    {loc.area_name}
+                  </a>
+                  <span className="text-muted-foreground">/</span>
+                  <span>{loc.room_name}</span>
+                  <span className="text-muted-foreground">
+                    ({loc.body_part})
+                  </span>
+                  {loc.material && <MaterialBadge mat={loc.material} />}
+                  {loc.grip && (
+                    <span className="text-muted-foreground">+ {loc.grip}</span>
+                  )}
+                  {loc.quantity > 1 && (
+                    <span className="text-muted-foreground">
+                      x{loc.quantity}
+                    </span>
+                  )}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className={cn(
+                          "ml-auto shrink-0 cursor-help",
+                          CHANCE_COLORS[loc.drop_chance] ??
+                            "text-muted-foreground"
+                        )}
+                      >
+                        {loc.drop_chance}
+                        {loc.drop_value > 0 &&
+                          loc.drop_chance !== "always" &&
+                          ` (${Math.round((loc.drop_value / 255) * 100)}%)`}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Raw drop value: {loc.drop_value}/255</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  {loc.condition && (
+                    <p className="text-muted-foreground w-full text-[10px]">
+                      {loc.condition}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -384,6 +384,23 @@ export interface MaterialRecipe {
   tier_change: number
 }
 
+export interface ItemDropLocation {
+  enemy_name: string
+  enemy_id: number
+  enemy_class: string
+  area_name: string
+  area_id: number
+  room_name: string
+  body_part: string
+  item: string
+  material: string
+  drop_chance: string
+  drop_value: number
+  grip: string
+  quantity: number
+  condition: string
+}
+
 async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${API_URL}${path}`)
   if (!res.ok) throw new Error(`API error: ${res.status}`)
@@ -434,6 +451,8 @@ export const gameApi = {
     fetchApi<MaterialRecipe[]>(
       `/crafting-recipes/materials${params ? `?${params}` : "?limit=200"}`
     ),
+  itemDrops: (item: string) =>
+    fetchApi<ItemDropLocation[]>(`/drops?item=${encodeURIComponent(item)}`),
 }
 
 export function fmt(s: string) {

--- a/src/routes/accessories/$id.tsx
+++ b/src/routes/accessories/$id.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
+import { ItemDropLocations } from "@/components/item-drop-locations"
 import { gameApi, fmt } from "@/lib/game-api"
 import { cn } from "@/lib/utils"
 
@@ -75,6 +76,7 @@ function AccessoryDetail() {
             </div>
           </div>
         </div>
+        <ItemDropLocations itemName={fmt(item.field_name)} />
       </CardContent>
     </Card>
   )

--- a/src/routes/armor/$id.tsx
+++ b/src/routes/armor/$id.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { MaterialSelect } from "@/components/material-select"
 import { StatDisplay } from "@/components/stat-display"
 import { ItemIcon } from "@/components/item-icon"
+import { ItemDropLocations } from "@/components/item-drop-locations"
 import { gameApi, fmt } from "@/lib/game-api"
 import { computeEffectiveStats, type ItemStats } from "@/lib/item-stats"
 
@@ -85,6 +86,7 @@ function ArmorDetail() {
             />
           </div>
         </div>
+        <ItemDropLocations itemName={fmt(item.field_name)} />
       </CardContent>
     </Card>
   )

--- a/src/routes/blades/$id.tsx
+++ b/src/routes/blades/$id.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { MaterialSelect } from "@/components/material-select"
 import { StatDisplay } from "@/components/stat-display"
 import { ItemIcon } from "@/components/item-icon"
+import { ItemDropLocations } from "@/components/item-drop-locations"
 import { gameApi, fmt } from "@/lib/game-api"
 import { computeEffectiveStats, type ItemStats } from "@/lib/item-stats"
 
@@ -113,6 +114,7 @@ function BladeDetail() {
             />
           </div>
         </div>
+        <ItemDropLocations itemName={fmt(blade.field_name)} />
       </CardContent>
     </Card>
   )

--- a/src/routes/consumables/$id.tsx
+++ b/src/routes/consumables/$id.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
+import { ItemDropLocations } from "@/components/item-drop-locations"
 import { gameApi } from "@/lib/game-api"
 
 export const Route = createFileRoute("/consumables/$id")({
@@ -72,6 +73,7 @@ function ConsumableDetail() {
             )}
           </div>
         </div>
+        <ItemDropLocations itemName={item.name} />
       </CardContent>
     </Card>
   )

--- a/src/routes/gems/$id.tsx
+++ b/src/routes/gems/$id.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
 import { StatDisplay } from "@/components/stat-display"
+import { ItemDropLocations } from "@/components/item-drop-locations"
 import { gameApi, fmt } from "@/lib/game-api"
 import type { ItemStats } from "@/lib/item-stats"
 
@@ -75,6 +76,7 @@ function GemDetail() {
             )}
           </div>
         </div>
+        <ItemDropLocations itemName={fmt(gem.field_name)} />
       </CardContent>
     </Card>
   )

--- a/src/routes/grips/$id.tsx
+++ b/src/routes/grips/$id.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { ItemIcon } from "@/components/item-icon"
+import { ItemDropLocations } from "@/components/item-drop-locations"
 import { gameApi, fmt } from "@/lib/game-api"
 import { cn } from "@/lib/utils"
 
@@ -67,6 +68,7 @@ function GripDetail() {
             </div>
           </div>
         </div>
+        <ItemDropLocations itemName={fmt(grip.field_name)} />
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
- Reusable `ItemDropLocations` component for showing which enemies drop an item and where
- Results grouped by enemy with bestiary links, class badges
- Per-location rows with area/room links, material badges, drop chance coloring and tooltips
- Added to all item detail pages: blades, armor, accessories, grips, gems, consumables

## Test plan
- [ ] Navigate to a blade detail (e.g. Battle Knife) — drop locations section appears
- [ ] Enemy names link to bestiary (new tab)
- [ ] Area names link to area detail (new tab)
- [ ] Drop chances colored and show tooltip on hover
- [ ] Items with no drops show no section
- [ ] Works on armor, consumable, grip, gem, accessory detail pages

Depends on API PR: ag-tech-group/vagrant-story-api#49