### PR TITLE
Collapsible Where to Find, fix mobile stat layout

### DIFF
--- a/src/components/item-drop-locations.tsx
+++ b/src/components/item-drop-locations.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
+import { ChevronRight } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import {
   Tooltip,
@@ -42,6 +43,8 @@ interface EnemyGroup {
 }
 
 export function ItemDropLocations({ itemName }: { itemName: string }) {
+  const [open, setOpen] = useState(false)
+
   const { data: drops = [], isLoading } = useQuery({
     queryKey: ["item-drops", itemName],
     queryFn: () => gameApi.itemDrops(itemName),
@@ -80,86 +83,107 @@ export function ItemDropLocations({ itemName }: { itemName: string }) {
 
   return (
     <div className="mt-6">
-      <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
-        Where to Find
-      </p>
-      <div className="space-y-2">
-        {grouped.map((group) => (
-          <div
-            key={group.enemy_id}
-            className="bg-muted/30 rounded px-3 py-2 text-xs"
-          >
-            <div className="flex items-center gap-2">
-              <a
-                href={`/bestiary/${group.enemy_id}`}
-                target="_blank"
-                rel="noreferrer"
-                className="text-primary hover:text-primary/80 font-medium underline decoration-dotted underline-offset-2"
-              >
-                {group.enemy_name}
-              </a>
-              <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-                {group.enemy_class}
-              </Badge>
-            </div>
-            <div className="mt-1.5 space-y-1">
-              {group.locations.map((loc, i) => (
-                <div
-                  key={`${loc.area_id}-${loc.room_name}-${loc.body_part}-${i}`}
-                  className="flex flex-wrap items-center gap-x-2 gap-y-0.5"
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="mb-2 flex w-full items-center gap-2"
+      >
+        <ChevronRight
+          className={cn(
+            "text-muted-foreground size-3.5 transition-transform",
+            open && "rotate-90"
+          )}
+        />
+        <p className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+          Where to Find
+        </p>
+        {!open && (
+          <span className="text-muted-foreground/60 text-[10px]">
+            {grouped.length} {grouped.length === 1 ? "enemy" : "enemies"}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="space-y-2">
+          {grouped.map((group) => (
+            <div
+              key={group.enemy_id}
+              className="bg-muted/30 rounded px-3 py-2 text-xs"
+            >
+              <div className="flex items-center gap-2">
+                <a
+                  href={`/bestiary/${group.enemy_id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary hover:text-primary/80 font-medium underline decoration-dotted underline-offset-2"
                 >
-                  <a
-                    href={`/areas/${loc.area_id}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-primary hover:text-primary/80 underline decoration-dotted underline-offset-2"
+                  {group.enemy_name}
+                </a>
+                <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                  {group.enemy_class}
+                </Badge>
+              </div>
+              <div className="mt-1.5 space-y-1">
+                {group.locations.map((loc, i) => (
+                  <div
+                    key={`${loc.area_id}-${loc.room_name}-${loc.body_part}-${i}`}
+                    className="flex flex-wrap items-center gap-x-2 gap-y-0.5"
                   >
-                    {loc.area_name}
-                  </a>
-                  <span className="text-muted-foreground">/</span>
-                  <span>{loc.room_name}</span>
-                  <span className="text-muted-foreground">
-                    ({loc.body_part})
-                  </span>
-                  {loc.material && <MaterialBadge mat={loc.material} />}
-                  {loc.grip && (
-                    <span className="text-muted-foreground">+ {loc.grip}</span>
-                  )}
-                  {loc.quantity > 1 && (
+                    <a
+                      href={`/areas/${loc.area_id}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary hover:text-primary/80 underline decoration-dotted underline-offset-2"
+                    >
+                      {loc.area_name}
+                    </a>
+                    <span className="text-muted-foreground">/</span>
+                    <span>{loc.room_name}</span>
                     <span className="text-muted-foreground">
-                      x{loc.quantity}
+                      ({loc.body_part})
                     </span>
-                  )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        className={cn(
-                          "ml-auto shrink-0 cursor-help",
-                          CHANCE_COLORS[loc.drop_chance] ??
-                            "text-muted-foreground"
-                        )}
-                      >
-                        {loc.drop_chance}
-                        {loc.drop_value > 0 &&
-                          loc.drop_chance !== "always" &&
-                          ` (${Math.round((loc.drop_value / 255) * 100)}%)`}
+                    {loc.material && <MaterialBadge mat={loc.material} />}
+                    {loc.grip && (
+                      <span className="text-muted-foreground">
+                        + {loc.grip}
                       </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Raw drop value: {loc.drop_value}/255</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  {loc.condition && (
-                    <p className="text-muted-foreground w-full text-[10px]">
-                      {loc.condition}
-                    </p>
-                  )}
-                </div>
-              ))}
+                    )}
+                    {loc.quantity > 1 && (
+                      <span className="text-muted-foreground">
+                        x{loc.quantity}
+                      </span>
+                    )}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className={cn(
+                            "ml-auto shrink-0 cursor-help",
+                            CHANCE_COLORS[loc.drop_chance] ??
+                              "text-muted-foreground"
+                          )}
+                        >
+                          {loc.drop_chance}
+                          {loc.drop_value > 0 &&
+                            loc.drop_chance !== "always" &&
+                            ` (${Math.round((loc.drop_value / 255) * 100)}%)`}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Raw drop value: {loc.drop_value}/255</p>
+                      </TooltipContent>
+                    </Tooltip>
+                    {loc.condition && (
+                      <p className="text-muted-foreground w-full text-[10px]">
+                        {loc.condition}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/stat-display.tsx
+++ b/src/components/stat-display.tsx
@@ -95,6 +95,13 @@ export function StatDisplay({
   showAffinities = false,
   compact = false,
 }: StatDisplayProps) {
+  const statCount =
+    3 +
+    (stats.range != null ? 1 : 0) +
+    (stats.damage != null ? 1 : 0) +
+    (stats.risk != null ? 1 : 0) +
+    (stats.gem_slots != null ? 1 : 0)
+
   return (
     <div className="flex flex-col items-center gap-1.5">
       {/* Damage type badge */}
@@ -105,7 +112,12 @@ export function StatDisplay({
       )}
 
       {/* Core stats */}
-      <div className="flex flex-wrap gap-1.5">
+      <div
+        className={cn(
+          "gap-1.5 sm:flex sm:flex-wrap",
+          statCount >= 6 ? "grid grid-cols-3" : "flex flex-wrap"
+        )}
+      >
         <Stat
           label="STR"
           value={stats.str}


### PR DESCRIPTION
## Summary
- Where to Find section on item detail pages starts collapsed with enemy count
- Stats use 3-column grid on mobile only when 6+ stats (blades), preserving flex-wrap for fewer stats (armor, grips)

## Test plan
- [ ] Item detail: Where to Find starts collapsed, expands on click
- [ ] Blade detail on mobile: stats show 3 per row evenly
- [ ] Armor detail on mobile: stats still flex-wrap naturally