### PR TITLE
Replace top nav tabs with sidebar navigation

### DIFF
--- a/src/components/database-select.tsx
+++ b/src/components/database-select.tsx
@@ -41,23 +41,28 @@ export function DatabaseSelect() {
   )
 
   return (
-    <Select
-      value={currentPage?.to ?? DATABASE_PAGES[0].to}
-      onValueChange={(v) => navigate({ to: v })}
-    >
-      <SelectTrigger className="h-9 w-fit">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {DATABASE_PAGES.map((page) => (
-          <SelectItem key={page.to} value={page.to}>
-            <div className="flex items-center gap-2">
-              <ItemIcon type={page.icon} size="sm" />
-              {page.label}
-            </div>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <div className="flex items-center gap-2">
+      <label className="text-muted-foreground text-xs font-medium">
+        Browse:
+      </label>
+      <Select
+        value={currentPage?.to ?? DATABASE_PAGES[0].to}
+        onValueChange={(v) => navigate({ to: v })}
+      >
+        <SelectTrigger className="border-primary/30 bg-primary/5 h-9 w-fit">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {DATABASE_PAGES.map((page) => (
+            <SelectItem key={page.to} value={page.to}>
+              <div className="flex items-center gap-2">
+                <ItemIcon type={page.icon} size="sm" />
+                {page.label}
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
   )
 }

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react"
+import { Link, useMatches } from "@tanstack/react-router"
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
+import { ItemIcon } from "@/components/item-icon"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const SIDEBAR_KEY = "vs-sidebar-open"
+
+interface NavItem {
+  to: string
+  label: string
+  icon: string
+}
+
+interface NavSection {
+  title: string
+  items: NavItem[]
+}
+
+const NAV_SECTIONS: NavSection[] = [
+  {
+    title: "Tools",
+    items: [
+      { to: "/forge", label: "Forge", icon: "Forge" },
+      { to: "/crafting", label: "Recipes", icon: "Crafting" },
+      { to: "/material-grid", label: "Material Grid", icon: "Grid" },
+      { to: "/inventory", label: "Inventory", icon: "Inventory" },
+    ],
+  },
+  {
+    title: "Equipment",
+    items: [
+      { to: "/blades", label: "Blades", icon: "Sword" },
+      { to: "/grips", label: "Grips", icon: "Grip" },
+      { to: "/armor", label: "Armor", icon: "Body" },
+      { to: "/accessories", label: "Accessories", icon: "Accessory" },
+      { to: "/gems", label: "Gems", icon: "Gem" },
+      { to: "/materials", label: "Materials", icon: "Bronze" },
+      { to: "/consumables", label: "Consumables", icon: "Consumable" },
+    ],
+  },
+  {
+    title: "Combat",
+    items: [
+      { to: "/break-arts", label: "Break Arts", icon: "BreakArt" },
+      {
+        to: "/battle-abilities",
+        label: "Battle Abilities",
+        icon: "BattleAbility",
+      },
+      { to: "/spells", label: "Spells", icon: "Spell" },
+      { to: "/grimoires", label: "Grimoires", icon: "Grimoire" },
+    ],
+  },
+  {
+    title: "World",
+    items: [
+      { to: "/bestiary", label: "Bestiary", icon: "Bestiary" },
+      { to: "/areas", label: "Areas", icon: "Area" },
+      { to: "/workshops", label: "Workshops", icon: "Workshop" },
+      { to: "/chests", label: "Chests", icon: "Chest" },
+      { to: "/characters", label: "Characters", icon: "Character" },
+    ],
+  },
+  {
+    title: "Progression",
+    items: [
+      { to: "/keys", label: "Keys", icon: "Key" },
+      { to: "/sigils", label: "Sigils", icon: "Sigil" },
+      { to: "/titles", label: "Titles", icon: "Title" },
+      { to: "/rankings", label: "Rankings", icon: "Ranking" },
+    ],
+  },
+]
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false
+  )
+  useEffect(() => {
+    const mql = window.matchMedia(query)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    mql.addEventListener("change", handler)
+    return () => mql.removeEventListener("change", handler)
+  }, [query])
+  return matches
+}
+
+export function SidebarNav() {
+  const isDesktop = useMediaQuery("(min-width: 1024px)")
+  const [open, setOpen] = useState(() => {
+    if (typeof window === "undefined") return true
+    const isLg = window.matchMedia("(min-width: 1024px)").matches
+    if (!isLg) return false
+    const stored = localStorage.getItem(SIDEBAR_KEY)
+    return stored !== null ? stored === "true" : true
+  })
+
+  const toggle = () => {
+    const next = !open
+    setOpen(next)
+    localStorage.setItem(SIDEBAR_KEY, String(next))
+  }
+
+  const matches = useMatches()
+  const currentPath = matches[matches.length - 1]?.fullPath ?? "/"
+
+  return (
+    <>
+      {/* Toggle button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={toggle}
+        className="fixed top-3 left-4 z-50 h-8 w-8 p-0"
+        title={open ? "Close sidebar" : "Open sidebar"}
+      >
+        {open ? (
+          <PanelLeftClose className="size-4" />
+        ) : (
+          <PanelLeftOpen className="size-4" />
+        )}
+      </Button>
+
+      {/* Overlay for mobile when open */}
+      {open && !isDesktop && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50"
+          onClick={() => setOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          "bg-background border-border/50 fixed top-14 z-40 h-[calc(100vh-3.5rem)] overflow-y-auto border-r transition-all duration-200",
+          open ? "w-52" : "w-0 -translate-x-full",
+          !isDesktop && open && "shadow-xl"
+        )}
+      >
+        <nav className="space-y-4 px-3 py-4">
+          {NAV_SECTIONS.map((section) => (
+            <div key={section.title}>
+              <p className="text-muted-foreground mb-1 px-2 text-[10px] font-semibold tracking-wider uppercase">
+                {section.title}
+              </p>
+              <div className="space-y-0.5">
+                {section.items.map((item) => {
+                  const isActive =
+                    currentPath === item.to ||
+                    currentPath.startsWith(item.to + "/")
+                  return (
+                    <Link
+                      key={item.to}
+                      to={item.to}
+                      onClick={() => {
+                        if (!isDesktop) setOpen(false)
+                      }}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+                        isActive
+                          ? "bg-primary/10 text-primary font-medium"
+                          : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                      )}
+                    >
+                      <ItemIcon type={item.icon} size="sm" />
+                      <span className="truncate">{item.label}</span>
+                    </Link>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Spacer to push content right when sidebar is open on desktop */}
+      {open && isDesktop && (
+        <div className="w-52 shrink-0 transition-all duration-200" />
+      )}
+    </>
+  )
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -5,7 +5,6 @@ import {
   Link,
   Outlet,
   useMatches,
-  useNavigate,
 } from "@tanstack/react-router"
 import { ChevronDown, ExternalLink, LogOut } from "lucide-react"
 import { Toaster } from "sonner"
@@ -18,19 +17,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { ItemIcon } from "@/components/item-icon"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { SidebarNav } from "@/components/sidebar-nav"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { UserAvatar } from "@/components/user-avatar"
 import { useAuth } from "@/lib/auth"
 import { loginUrl, profileUrl } from "@/lib/config"
-import { cn } from "@/lib/utils"
 
 const TanStackRouterDevtools = import.meta.env.PROD
   ? () => null
@@ -67,54 +58,20 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
 })
 
-const DATABASE_ROUTES = [
-  "/blades",
-  "/grips",
-  "/armor",
-  "/materials",
-  "/accessories",
-  "/gems",
-  "/consumables",
-  "/break-arts",
-  "/battle-abilities",
-  "/spells",
-  "/grimoires",
-  "/keys",
-  "/sigils",
-  "/workshops",
-  "/areas",
-  "/bestiary",
-]
-
-const NAV_TABS = [
-  { to: "/blades" as const, label: "Game Database", icon: "Sword" },
-  { to: "/forge" as const, label: "Forge", icon: "Forge" },
-  { to: "/crafting" as const, label: "Recipes", icon: "Crafting" },
-  { to: "/material-grid" as const, label: "Material Grid", icon: "Grid" },
-  { to: "/inventory" as const, label: "Inventory", icon: "Inventory" },
-]
-
 function RootComponent() {
   const auth = useAuth()
 
   const matches = useMatches()
-  const navigate = useNavigate()
   const currentPath = matches[matches.length - 1]?.fullPath ?? "/"
-  const showTabs = currentPath !== "/"
-  const isOnDatabaseRoute = DATABASE_ROUTES.some(
-    (r) => currentPath === r || currentPath.startsWith(r + "/")
-  )
-  const activeTab = isOnDatabaseRoute
-    ? NAV_TABS[0]
-    : NAV_TABS.find(
-        (t) => currentPath === t.to || currentPath.startsWith(t.to + "/")
-      )
+  const isHome = currentPath === "/"
 
   return (
     <TooltipProvider delayDuration={300}>
       <nav className="border-border/50 bg-background/80 fixed top-0 z-50 w-full border-b backdrop-blur-sm">
         <div className="flex h-14 items-center justify-between px-4">
           <div className="flex items-center gap-6">
+            {/* Leave space for sidebar toggle on non-home pages */}
+            {!isHome && <div className="w-8" />}
             <Link
               to="/"
               className="hover:text-primary font-sans text-lg tracking-wide transition-colors"
@@ -161,70 +118,9 @@ function RootComponent() {
             )}
           </div>
         </div>
-        {showTabs && (
-          <>
-            {/* Desktop: tab row with icons */}
-            <div className="border-border/50 hidden gap-0 overflow-x-auto border-t px-4 lg:flex">
-              {NAV_TABS.map((tab) => {
-                const isActive =
-                  tab.to === "/blades"
-                    ? isOnDatabaseRoute
-                    : currentPath === tab.to ||
-                      currentPath.startsWith(tab.to + "/")
-                return (
-                  <Link
-                    key={tab.to}
-                    to={tab.to}
-                    className={cn(
-                      "text-muted-foreground hover:text-foreground relative flex shrink-0 items-center gap-1.5 px-3 py-2 text-sm transition-colors",
-                      isActive && "text-foreground"
-                    )}
-                  >
-                    <span
-                      className="bg-primary block size-3.5"
-                      style={{
-                        mask: `url(/images/icons/${tab.icon}.svg) center/contain no-repeat`,
-                        WebkitMask: `url(/images/icons/${tab.icon}.svg) center/contain no-repeat`,
-                      }}
-                    />
-                    {tab.label}
-                    {isActive && (
-                      <span className="bg-primary absolute bottom-0 left-0 h-0.5 w-full rounded-full" />
-                    )}
-                  </Link>
-                )
-              })}
-            </div>
-            {/* Mobile: select dropdown */}
-            <div className="border-border/50 border-t px-4 py-2 lg:hidden">
-              <Select
-                value={activeTab?.to ?? NAV_TABS[0].to}
-                onValueChange={(v) => navigate({ to: v })}
-              >
-                <SelectTrigger className="h-9 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {NAV_TABS.map((tab) => (
-                    <SelectItem key={tab.to} value={tab.to}>
-                      <div className="flex items-center gap-2">
-                        <ItemIcon type={tab.icon} size="sm" />
-                        {tab.label}
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </>
-        )}
       </nav>
-      <div
-        className={cn(
-          "relative flex min-h-screen flex-col",
-          showTabs ? "pt-[6.75rem] lg:pt-[6.25rem]" : "pt-14"
-        )}
-      >
+      <div className="relative flex min-h-screen pt-14">
+        {!isHome && <SidebarNav />}
         <div
           className="pointer-events-none fixed inset-0 z-0 bg-center bg-no-repeat opacity-[0.04] brightness-0 dark:invert"
           style={{
@@ -232,37 +128,37 @@ function RootComponent() {
             backgroundSize: "auto 80vh",
           }}
         />
-        <div className="relative z-10 flex flex-1 flex-col">
+        <div className="relative z-10 flex min-w-0 flex-1 flex-col">
           <Outlet />
-        </div>
-        <footer className="border-border/50 border-t px-4 py-3">
-          <div className="text-muted-foreground flex items-center justify-between text-xs">
-            <p>
-              &copy; {new Date().getFullYear()} AG Technology Group LLC. All
-              rights reserved.
-            </p>
-            <div className="flex gap-4">
-              <a
-                href="https://criticalbit.gg"
-                className="hover:text-foreground transition-colors"
-              >
-                criticalbit.gg
-              </a>
-              <a
-                href="https://criticalbit.gg/privacy"
-                className="hover:text-foreground transition-colors"
-              >
-                Privacy
-              </a>
-              <a
-                href="https://criticalbit.gg/terms"
-                className="hover:text-foreground transition-colors"
-              >
-                Terms
-              </a>
+          <footer className="border-border/50 mt-auto border-t px-4 py-3">
+            <div className="text-muted-foreground flex items-center justify-between text-xs">
+              <p>
+                &copy; {new Date().getFullYear()} AG Technology Group LLC. All
+                rights reserved.
+              </p>
+              <div className="flex gap-4">
+                <a
+                  href="https://criticalbit.gg"
+                  className="hover:text-foreground transition-colors"
+                >
+                  criticalbit.gg
+                </a>
+                <a
+                  href="https://criticalbit.gg/privacy"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Privacy
+                </a>
+                <a
+                  href="https://criticalbit.gg/terms"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Terms
+                </a>
+              </div>
             </div>
-          </div>
-        </footer>
+          </footer>
+        </div>
       </div>
       <Toaster position="bottom-right" richColors closeButton />
       <Suspense fallback={null}>

--- a/src/routes/accessories/route.tsx
+++ b/src/routes/accessories/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { AccessoriesPage } from "@/pages/accessories/accessories-page"
 
 export const Route = createFileRoute("/accessories")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <AccessoriesPage />
     </div>

--- a/src/routes/areas/route.tsx
+++ b/src/routes/areas/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { AreasPage } from "@/pages/areas/areas-page"
 
 export const Route = createFileRoute("/areas")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <AreasPage />
     </div>

--- a/src/routes/armor/route.tsx
+++ b/src/routes/armor/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { ArmorPage } from "@/pages/armor/armor-page"
 
 export const Route = createFileRoute("/armor")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <ArmorPage />
     </div>

--- a/src/routes/battle-abilities/route.tsx
+++ b/src/routes/battle-abilities/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { BattleAbilitiesPage } from "@/pages/battle-abilities/battle-abilities-page"
 
 export const Route = createFileRoute("/battle-abilities")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <BattleAbilitiesPage />
     </div>

--- a/src/routes/bestiary/route.tsx
+++ b/src/routes/bestiary/route.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { BestiaryPage } from "@/pages/bestiary/bestiary-page"
 
 export const Route = createFileRoute("/bestiary")({
@@ -9,7 +8,6 @@ export const Route = createFileRoute("/bestiary")({
 function BestiaryLayout() {
   return (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <BestiaryPage />
     </div>

--- a/src/routes/blades/route.tsx
+++ b/src/routes/blades/route.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { BladesPage } from "@/pages/blades/blades-page"
 
 export const Route = createFileRoute("/blades")({
@@ -9,7 +8,6 @@ export const Route = createFileRoute("/blades")({
 function BladesLayout() {
   return (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <BladesPage />
     </div>

--- a/src/routes/break-arts/route.tsx
+++ b/src/routes/break-arts/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { BreakArtsPage } from "@/pages/break-arts/break-arts-page"
 
 export const Route = createFileRoute("/break-arts")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <BreakArtsPage />
     </div>

--- a/src/routes/characters/route.tsx
+++ b/src/routes/characters/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { CharactersPage } from "@/pages/characters/characters-page"
 
 export const Route = createFileRoute("/characters")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <CharactersPage />
     </div>

--- a/src/routes/chests/route.tsx
+++ b/src/routes/chests/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { ChestsPage } from "@/pages/chests/chests-page"
 
 export const Route = createFileRoute("/chests")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <ChestsPage />
     </div>

--- a/src/routes/consumables/route.tsx
+++ b/src/routes/consumables/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { ConsumablesPage } from "@/pages/consumables/consumables-page"
 
 export const Route = createFileRoute("/consumables")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <ConsumablesPage />
     </div>

--- a/src/routes/gems/route.tsx
+++ b/src/routes/gems/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { GemsPage } from "@/pages/gems/gems-page"
 
 export const Route = createFileRoute("/gems")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <GemsPage />
     </div>

--- a/src/routes/grimoires/route.tsx
+++ b/src/routes/grimoires/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { GrimoiresPage } from "@/pages/grimoires/grimoires-page"
 
 export const Route = createFileRoute("/grimoires")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <GrimoiresPage />
     </div>

--- a/src/routes/grips/route.tsx
+++ b/src/routes/grips/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { GripsPage } from "@/pages/grips/grips-page"
 
 export const Route = createFileRoute("/grips")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <GripsPage />
     </div>

--- a/src/routes/materials.tsx
+++ b/src/routes/materials.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { MaterialsPage } from "@/pages/materials/materials-page"
 
 export const Route = createFileRoute("/materials")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <MaterialsPage />
     </div>
   ),

--- a/src/routes/rankings/route.tsx
+++ b/src/routes/rankings/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { RankingsPage } from "@/pages/rankings/rankings-page"
 
 export const Route = createFileRoute("/rankings")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <RankingsPage />
     </div>

--- a/src/routes/sigils/route.tsx
+++ b/src/routes/sigils/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { SigilsPage } from "@/pages/sigils/sigils-page"
 
 export const Route = createFileRoute("/sigils")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <SigilsPage />
     </div>

--- a/src/routes/spells/route.tsx
+++ b/src/routes/spells/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { SpellsPage } from "@/pages/spells/spells-page"
 
 export const Route = createFileRoute("/spells")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <SpellsPage />
     </div>

--- a/src/routes/titles/route.tsx
+++ b/src/routes/titles/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { TitlesPage } from "@/pages/titles/titles-page"
 
 export const Route = createFileRoute("/titles")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <TitlesPage />
     </div>

--- a/src/routes/workshops/route.tsx
+++ b/src/routes/workshops/route.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
-import { DatabaseSelect } from "@/components/database-select"
 import { WorkshopsPage } from "@/pages/workshops/workshops-page"
 
 export const Route = createFileRoute("/workshops")({
   component: () => (
     <div className="flex flex-1 flex-col gap-6 p-6 lg:p-10">
-      <DatabaseSelect />
       <Outlet />
       <WorkshopsPage />
     </div>


### PR DESCRIPTION
## Summary
- New sidebar nav with 5 sections: Tools, Equipment, Combat, World, Progression
- Replaces top nav tabs (Game Database, Forge, Recipes, etc.) and DatabaseSelect dropdown
- Toggle open/closed with panel icons, state persisted to localStorage
- Open by default on desktop (lg+), closed on mobile with overlay backdrop
- Active route highlighted with primary color
- Hidden on homepage
- Consumables under Equipment section

## Test plan
- [ ] Sidebar visible on all pages except homepage
- [ ] Toggle opens/closes sidebar, persists across page navigation
- [ ] Active route highlighted correctly
- [ ] Mobile: sidebar overlays with backdrop, closes on item click
- [ ] Desktop: sidebar pushes content right
- [ ] All 24 nav items work and route correctly