### PR TITLE
feat: Ashley base stats display and grip mapping fix

### DIFF
--- a/src/components/inventory-preview.tsx
+++ b/src/components/inventory-preview.tsx
@@ -111,7 +111,16 @@ export function ReadOnlyBagItemRow({
   )
 }
 
-export function StatBox({ label, value }: { label: string; value: number }) {
+export function StatBox({
+  label,
+  value,
+  diff,
+}: {
+  label: string
+  value: number
+  /** Optional equipment modifier shown as (+N) or (-N) */
+  diff?: number
+}) {
   return (
     <div className="bg-muted/50 flex min-w-11 flex-col items-center rounded px-2 py-1.5">
       <span className="text-muted-foreground text-xs leading-none">
@@ -127,6 +136,16 @@ export function StatBox({ label, value }: { label: string; value: number }) {
       >
         {value}
       </span>
+      {diff != null && diff !== 0 && (
+        <span
+          className={cn(
+            "text-[10px] leading-none font-medium",
+            diff > 0 ? "text-green-400/70" : "text-red-400/70"
+          )}
+        >
+          ({diff > 0 ? `+${diff}` : diff})
+        </span>
+      )}
     </div>
   )
 }

--- a/src/lib/inventory-api.ts
+++ b/src/lib/inventory-api.ts
@@ -33,6 +33,11 @@ export interface InventoryItem {
 }
 
 export interface InventoryDetail extends InventoryListItem {
+  base_hp: number | null
+  base_mp: number | null
+  base_str: number | null
+  base_int: number | null
+  base_agi: number | null
   items: InventoryItem[]
 }
 
@@ -219,11 +224,22 @@ export const inventoryApi = {
   importItems: (
     inventoryId: number,
     items: CreateInventoryItem[],
-    clearExisting: boolean = false
+    clearExisting: boolean = false,
+    characterStats?: {
+      base_hp: number
+      base_mp: number
+      base_str: number
+      base_int: number
+      base_agi: number
+    }
   ) =>
     fetchAuth<InventoryDetail>(`/user/inventories/${inventoryId}/import`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ items, clear_existing: clearExisting }),
+      body: JSON.stringify({
+        items,
+        clear_existing: clearExisting,
+        ...characterStats,
+      }),
     }),
 }

--- a/src/lib/save-import-mapper.ts
+++ b/src/lib/save-import-mapper.ts
@@ -52,7 +52,7 @@ function bladeApiId(saveId: number): number {
 }
 
 function gripApiId(saveId: number): number {
-  return saveId - 95 // 96→1, 126→31
+  return saveId - 2 // ITEMNAME 96→94, 102→100 (matches grips.id in DB)
 }
 
 function armorApiId(saveId: number): number {
@@ -81,11 +81,17 @@ interface GameData {
 }
 
 function buildIdMap<T extends { id: number; game_id?: number }>(
-  items: T[]
+  items: T[],
+  keyBy: "game_id" | "id" = "game_id"
 ): Map<number, T> {
   const map = new Map<number, T>()
   for (const item of items) {
-    const key = item.game_id && item.game_id > 0 ? item.game_id : item.id
+    const key =
+      keyBy === "id"
+        ? item.id
+        : item.game_id && item.game_id > 0
+          ? item.game_id
+          : item.id
     map.set(key, item)
   }
   return map
@@ -107,7 +113,7 @@ export function mapSaveSlotToItems(
 ): MapperResult {
   const bladeById = buildIdMap(gameData.blades)
   const armorById = buildIdMap(gameData.armor)
-  const gripById = buildIdMap(gameData.grips)
+  const gripById = buildIdMap(gameData.grips, "id")
   const gemById = buildIdMap(gameData.gems)
   // Track assigned equip slots to avoid duplicates (e.g. R.Arm + L.Arm → one "arms" slot)
   const usedEquipSlots = new Set<EquipSlot>()

--- a/src/lib/save-parser.ts
+++ b/src/lib/save-parser.ts
@@ -36,6 +36,19 @@ const MATERIALS = [
 
 // ── Types ────────────────────────────────────────────────────────────
 
+export interface ParsedCharacterStats {
+  hp: number
+  maxHp: number
+  mp: number
+  maxMp: number
+  /** Base STR (before equipment modifiers) */
+  str: number
+  /** Base INT (before equipment modifiers) */
+  int: number
+  /** Base AGI (before equipment modifiers) */
+  agi: number
+}
+
 export interface ParsedSaveSlot {
   slotNumber: number
   zoneId: number
@@ -48,6 +61,8 @@ export interface ParsedSaveSlot {
   saveCount: number
   clearCount: number // NG+ counter
   mapCompletion: number
+  /** Ashley's base character stats (before equipment modifiers) */
+  characterStats: ParsedCharacterStats
   checksumValid: boolean
   checksumErrors: string[]
   inventory: ParsedInventory
@@ -427,6 +442,25 @@ function parseSaveSummary(view: DataView): SaveSummary {
     saveCount: view.getUint16(0x194, true),
     clearCount: view.getUint8(0x19d),
     mapCompletion: view.getUint8(0x19e),
+  }
+}
+
+/**
+ * Parse Ashley's base character stats from offset 0x06CC.
+ *
+ * The character block stores HP/MP/STR/INT/AGI as uint16 LE pairs
+ * (current, max). The game saves base stats only — equipment modifiers
+ * are recalculated at load time.
+ */
+function parseCharacterStats(view: DataView): ParsedCharacterStats {
+  return {
+    hp: view.getUint16(0x06cc, true),
+    maxHp: view.getUint16(0x06ce, true),
+    mp: view.getUint16(0x06d0, true),
+    maxMp: view.getUint16(0x06d2, true),
+    str: view.getUint16(0x06d4, true),
+    int: view.getUint16(0x06d8, true),
+    agi: view.getUint16(0x06dc, true),
   }
 }
 
@@ -930,8 +964,9 @@ function parseSaveSlot(
   const zoneId = decrypted[0x1778]
   const roomId = decrypted[0x1779]
 
-  // Parse save summary
+  // Parse save summary and character stats
   const summary = parseSaveSummary(decView)
+  const characterStats = parseCharacterStats(decView)
 
   // Parse active inventory and workshop container
   const inventory = parseInventory(decrypted, decView, ACTIVE_LAYOUT)
@@ -949,6 +984,7 @@ function parseSaveSlot(
     saveCount: summary.saveCount,
     clearCount: summary.clearCount,
     mapCompletion: summary.mapCompletion,
+    characterStats,
     checksumValid,
     checksumErrors,
     inventory,

--- a/src/pages/inventory/import-page.tsx
+++ b/src/pages/inventory/import-page.tsx
@@ -310,9 +310,16 @@ function ImportFlow() {
           console.warn(`Import warnings for "${name}":`, warnings)
         }
 
-        // Batch import
+        // Batch import with character stats
         if (items.length > 0) {
-          await inventoryApi.importItems(inventory.id, items, true)
+          const cs = slot.characterStats
+          await inventoryApi.importItems(inventory.id, items, true, {
+            base_hp: cs.maxHp,
+            base_mp: cs.maxMp,
+            base_str: cs.str,
+            base_int: cs.int,
+            base_agi: cs.agi,
+          })
         }
 
         createdIds.push(inventory.id)
@@ -848,6 +855,18 @@ function SlotCard({
                   {slot.mp}
                   <span className="text-muted-foreground">·</span>
                   {slot.maxMp}
+                </span>
+              </div>
+              {/* Base stats */}
+              <div className="flex items-center gap-2 font-mono text-xs">
+                <span className="text-green-400">
+                  STR {slot.characterStats.str}
+                </span>
+                <span className="text-blue-400">
+                  INT {slot.characterStats.int}
+                </span>
+                <span className="text-yellow-400">
+                  AGI {slot.characterStats.agi}
                 </span>
               </div>
               {/* TIME */}

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -926,7 +926,21 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
 
       {/* Loadout Tab */}
       {activeTab === "loadout" && (
-        <LoadoutTab items={allItems} inventoryId={inventoryId} />
+        <LoadoutTab
+          items={allItems}
+          inventoryId={inventoryId}
+          baseStats={
+            inventory.base_str != null
+              ? {
+                  hp: inventory.base_hp ?? 0,
+                  mp: inventory.base_mp ?? 0,
+                  str: inventory.base_str,
+                  int: inventory.base_int ?? 0,
+                  agi: inventory.base_agi ?? 0,
+                }
+              : undefined
+          }
+        />
       )}
 
       {/* Equipment Tab */}
@@ -1048,7 +1062,20 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
                 {/* Combined Stats */}
                 {combinedStats &&
                   inventory.items.some((i) => i.equip_slot != null) && (
-                    <CombinedStatsCard stats={combinedStats} />
+                    <CombinedStatsCard
+                      stats={combinedStats}
+                      baseStats={
+                        inventory.base_str != null
+                          ? {
+                              hp: inventory.base_hp ?? 0,
+                              mp: inventory.base_mp ?? 0,
+                              str: inventory.base_str,
+                              int: inventory.base_int ?? 0,
+                              agi: inventory.base_agi ?? 0,
+                            }
+                          : undefined
+                      }
+                    />
                   )}
               </div>
 
@@ -1679,6 +1706,7 @@ function DraggableBagItemRow({
 
 function CombinedStatsCard({
   stats,
+  baseStats,
 }: {
   stats: {
     str: number
@@ -1705,6 +1733,7 @@ function CombinedStatsCard({
     dark: number
     hasBlade: boolean
   }
+  baseStats?: { hp: number; mp: number; str: number; int: number; agi: number }
 }) {
   return (
     <Card className="mx-auto max-w-sm lg:max-w-none">
@@ -1713,27 +1742,58 @@ function CombinedStatsCard({
           Combined Stats
         </p>
 
-        {/* Core stats */}
-        <div className="flex flex-wrap justify-center gap-1.5">
-          <StatBox label="STR" value={stats.str} />
-          <StatBox label="INT" value={stats.int} />
-          <StatBox label="AGI" value={stats.agi} />
-          {stats.hasBlade && (
-            <>
-              <StatBox label="RNG" value={stats.range} />
-              <StatBox label="RSK" value={stats.risk} />
-            </>
-          )}
-        </div>
+        {/* Base + equipment core stats */}
+        {baseStats ? (
+          <div className="space-y-1.5">
+            <div className="flex flex-wrap justify-center gap-1.5">
+              <StatBox
+                label="STR"
+                value={baseStats.str + stats.str}
+                diff={stats.str}
+              />
+              <StatBox
+                label="INT"
+                value={baseStats.int + stats.int}
+                diff={stats.int}
+              />
+              <StatBox
+                label="AGI"
+                value={baseStats.agi + stats.agi}
+                diff={stats.agi}
+              />
+              {stats.hasBlade && (
+                <>
+                  <StatBox label="RNG" value={stats.range} />
+                  <StatBox label="RSK" value={stats.risk} />
+                </>
+              )}
+            </div>
+            <p className="text-muted-foreground/60 text-center text-[9px]">
+              Base + equipment modifier
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-wrap justify-center gap-1.5">
+            <StatBox label="STR" value={stats.str} />
+            <StatBox label="INT" value={stats.int} />
+            <StatBox label="AGI" value={stats.agi} />
+            {stats.hasBlade && (
+              <>
+                <StatBox label="RNG" value={stats.range} />
+                <StatBox label="RSK" value={stats.risk} />
+              </>
+            )}
+          </div>
+        )}
 
         {/* Damage type stats */}
-        {stats.hasBlade && (stats.blunt || stats.edged || stats.piercing) ? (
+        {stats.hasBlade && (
           <div className="flex flex-wrap justify-center gap-1.5">
             <StatBox label="Blt" value={stats.blunt} />
             <StatBox label="Edg" value={stats.edged} />
             <StatBox label="Prc" value={stats.piercing} />
           </div>
-        ) : null}
+        )}
 
         {/* Class affinities */}
         <div className="flex flex-wrap justify-center gap-1.5">

--- a/src/pages/inventory/loadout-tab.tsx
+++ b/src/pages/inventory/loadout-tab.tsx
@@ -27,14 +27,23 @@ import { cn } from "@/lib/utils"
 
 type Mode = "full" | "offense" | "defense"
 
+interface BaseStats {
+  hp: number
+  mp: number
+  str: number
+  int: number
+  agi: number
+}
+
 interface LoadoutTabProps {
   items: InventoryItem[]
   inventoryId: number
+  baseStats?: BaseStats
 }
 
 // ── Main component ──────────────────────────────────────────────────
 
-export function LoadoutTab({ items, inventoryId }: LoadoutTabProps) {
+export function LoadoutTab({ items, inventoryId, baseStats }: LoadoutTabProps) {
   const [selectedEnemy, setSelectedEnemy] = useState<string | null>(null)
   const [mode, setMode] = useState<Mode>("full")
   const [includeEquipped, setIncludeEquipped] = useState(true)
@@ -234,6 +243,7 @@ export function LoadoutTab({ items, inventoryId }: LoadoutTabProps) {
                 enemy={result.enemy}
                 mode={mode}
                 enemies={enemies}
+                baseStats={baseStats}
               />
             ))
           )}
@@ -251,12 +261,14 @@ function LoadoutCard({
   enemy,
   mode,
   enemies,
+  baseStats,
 }: {
   loadout: LoadoutResult
   previousLoadout?: LoadoutResult
   enemy: LoadoutResponse["enemy"]
   mode: Mode
   enemies: Enemy[]
+  baseStats?: BaseStats
 }) {
   const fullEnemy = enemies.find((e) => e.id === enemy.id)
 
@@ -343,7 +355,10 @@ function LoadoutCard({
           />
 
           {/* Right: Player combined stats */}
-          <CombinedStatsPanel stats={loadout.combined_stats} />
+          <CombinedStatsPanel
+            stats={loadout.combined_stats}
+            baseStats={baseStats}
+          />
         </div>
       </CardContent>
     </Card>
@@ -622,30 +637,61 @@ const EMPTY_COMBINED_STATS: import("@/lib/inventory-api").LoadoutCombinedStats =
 
 function CombinedStatsPanel({
   stats: rawStats,
+  baseStats,
 }: {
   stats: import("@/lib/inventory-api").LoadoutCombinedStats | null
+  baseStats?: BaseStats
 }) {
   const stats = rawStats ?? EMPTY_COMBINED_STATS
   return (
     <div className="space-y-2">
       <p className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
-        Loadout Stats
+        {baseStats ? "Combined Stats" : "Loadout Stats"}
       </p>
-      <p className="text-muted-foreground/60 text-[9px]">
-        Equipment contribution only
-      </p>
+      {!baseStats && (
+        <p className="text-muted-foreground/60 text-[9px]">
+          Equipment contribution only
+        </p>
+      )}
       {stats.damage_type && (
         <div className="flex justify-center">
           <DamageTypeBadge type={stats.damage_type} />
         </div>
       )}
       <div className="grid grid-cols-3 gap-1">
-        <StatBadge label="STR" value={stats.str} />
-        <StatBadge label="INT" value={stats.int} />
-        <StatBadge label="AGI" value={stats.agi} />
+        {baseStats ? (
+          <>
+            <StatBadge
+              label="STR"
+              value={baseStats.str + stats.str}
+              diff={stats.str}
+            />
+            <StatBadge
+              label="INT"
+              value={baseStats.int + stats.int}
+              diff={stats.int}
+            />
+            <StatBadge
+              label="AGI"
+              value={baseStats.agi + stats.agi}
+              diff={stats.agi}
+            />
+          </>
+        ) : (
+          <>
+            <StatBadge label="STR" value={stats.str} />
+            <StatBadge label="INT" value={stats.int} />
+            <StatBadge label="AGI" value={stats.agi} />
+          </>
+        )}
         {stats.range > 0 && <StatBadge label="RNG" value={stats.range} />}
         {stats.risk > 0 && <StatBadge label="RSK" value={stats.risk} />}
       </div>
+      {baseStats && (
+        <p className="text-muted-foreground/60 text-[9px]">
+          Base + equipment modifier
+        </p>
+      )}
       <div className="grid grid-cols-3 gap-1">
         <StatBadge label="Blt" value={stats.blunt} />
         <StatBadge label="Edg" value={stats.edged} />
@@ -677,7 +723,15 @@ function CombinedStatsPanel({
 
 // ── Utility ─────────────────────────────────────────────────────────
 
-function StatBadge({ label, value }: { label: string; value: number }) {
+function StatBadge({
+  label,
+  value,
+  diff,
+}: {
+  label: string
+  value: number
+  diff?: number
+}) {
   return (
     <div className="bg-muted/50 flex min-w-10 flex-col items-center rounded px-1.5 py-1">
       <span className="text-muted-foreground text-[10px] leading-none">
@@ -693,6 +747,16 @@ function StatBadge({ label, value }: { label: string; value: number }) {
       >
         {value}
       </span>
+      {diff != null && diff !== 0 && (
+        <span
+          className={cn(
+            "text-[10px] leading-none font-medium",
+            diff > 0 ? "text-green-400/70" : "text-red-400/70"
+          )}
+        >
+          ({diff > 0 ? `+${diff}` : diff})
+        </span>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Parse Ashley's base STR/INT/AGI from memory card save data (offset `0x06CC`) and persist via import
- Show base + equipment = total stats with diff modifier on equipment and loadout tabs
- Show STR/INT/AGI on import page save slot preview cards
- Fix grip ID mapping: use `id`-based lookup (`gripApiId = saveId - 2`) instead of broken `game_id` mapping
- Always show Blt/Edg/Prc row in equipment tab when blade is equipped
- Add `diff` prop to StatBox and StatBadge for equipment modifier display

## Test plan
- [x] Import page shows STR/INT/AGI on slot cards
- [x] Equipment tab shows combined stats with base + equipment diff
- [x] Loadout tab shows combined stats matching equipment tab
- [x] Grip mapping resolves correctly (Power Palm id=100 for Khopesh)