### PR TITLE
fix: security hardening for CI, CSP, and auth state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* https://*.criticalbit.gg; img-src 'self' data: https:; object-src 'none'; frame-src 'none'; base-uri 'self'"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.criticalbit.gg; img-src 'self' data: https:; object-src 'none'; frame-src 'none'; form-action 'self'; upgrade-insecure-requests; base-uri 'self'"
     />
     <title>Vagrant Story — criticalbit.gg</title>
   </head>

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -9,8 +9,6 @@ import {
 } from "react"
 import { api, setOnUnauthorized } from "@/api/api"
 
-const EMAIL_KEY = "app_auth_email"
-
 interface AuthContextValue {
   isAuthenticated: boolean
   isLoading: boolean
@@ -29,15 +27,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const queryClient = useQueryClient()
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
-  const [email, setEmail] = useState<string | null>(() =>
-    localStorage.getItem(EMAIL_KEY)
-  )
+  const [email, setEmail] = useState<string | null>(null)
   const [userId, setUserId] = useState<string | null>(null)
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
 
   const clearState = useCallback(() => {
-    localStorage.removeItem(EMAIL_KEY)
     setIsAuthenticated(false)
     setEmail(null)
     setUserId(null)
@@ -56,7 +51,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [clearState])
 
   const login = useCallback((newEmail: string) => {
-    localStorage.setItem(EMAIL_KEY, newEmail)
     setEmail(newEmail)
     setIsAuthenticated(true)
   }, [])
@@ -74,7 +68,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUserId(user.id)
       setDisplayName(user.display_name)
       setAvatarUrl(user.avatar_url)
-      localStorage.setItem(EMAIL_KEY, user.email)
     } catch {
       clearState()
     } finally {


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to CI workflow for least-privilege `GITHUB_TOKEN`
- Remove `http://localhost:*` from CSP `connect-src` (dev-only, unnecessary in production since Vite proxy is same-origin)
- Add `form-action 'self'` and `upgrade-insecure-requests` CSP directives
- Remove email persistence from `localStorage`; now in-memory only, sourced from `/auth/me` on each page load

## Test plan
- [ ] Verify CI passes with restricted permissions
- [ ] Verify site loads correctly in production (CSP not blocking legitimate requests)
- [ ] Verify login/logout flow still works without localStorage email caching