### PR TITLE
fix: classify chest body part drops as equipment in bestiary

### DIFF
--- a/src/routes/bestiary/$id.tsx
+++ b/src/routes/bestiary/$id.tsx
@@ -357,12 +357,8 @@ function EnemyDetail() {
 }
 
 function groupDrops(drops: EnemyDrop[]) {
-  const equipment = drops.filter(
-    (d) => d.body_part !== "Misc" && d.body_part !== "Chest"
-  )
-  const consumables = drops.filter(
-    (d) => d.body_part === "Misc" || d.body_part === "Chest"
-  )
+  const equipment = drops.filter((d) => d.body_part !== "Misc")
+  const consumables = drops.filter((d) => d.body_part === "Misc")
   const groups: { label: string; items: EnemyDrop[] }[] = []
   if (equipment.length > 0)
     groups.push({ label: "Equipment", items: equipment })


### PR DESCRIPTION
## Summary
- Fixed `groupDrops()` in bestiary detail page incorrectly classifying "Chest" body part drops as consumables
- "Chest" is a body part (like Head, Body, Arm, Leg) that drops equipment — only "Misc" should be classified as consumables

Fixes #108