### PR TITLE
refactor: rename inventory optimizer tab to workbench

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Routes live in `src/routes/`. The route tree is auto-generated (`src/routeTree.g
 
 **Route components import page components from `src/pages/`** — routes are thin wrappers.
 
-**Inventory uses subroutes** for tab persistence: `$inventoryId/equipment.tsx` and `$inventoryId/optimizer.tsx`. Tab selection is URL-driven, not React state.
+**Inventory uses subroutes** for tab persistence: `$inventoryId/equipment.tsx` and `$inventoryId/workbench.tsx`. Tab selection is URL-driven, not React state.
 
 ### Navigation
 

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -148,10 +148,10 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
   })
     ? "loadout"
     : matchRoute({
-          to: "/inventory/$inventoryId/optimizer",
+          to: "/inventory/$inventoryId/workbench",
           params: { inventoryId: String(inventoryId) },
         })
-      ? "optimizer"
+      ? "workbench"
       : "equipment"
   const [editingSlot, setEditingSlot] = useState<SlotConfig | null>(null)
   const [editingBagItem, setEditingBagItem] = useState(false)
@@ -872,11 +872,11 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
           )}
         </Link>
         <Link
-          to="/inventory/$inventoryId/optimizer"
+          to="/inventory/$inventoryId/workbench"
           params={{ inventoryId: String(inventoryId) }}
           className={cn(
             "relative flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors",
-            activeTab === "optimizer"
+            activeTab === "workbench"
               ? "text-foreground"
               : "text-muted-foreground hover:text-foreground"
           )}
@@ -889,8 +889,8 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
                 "url(/images/icons/HammerPick.svg) center / contain no-repeat",
             }}
           />
-          Optimizer
-          {activeTab === "optimizer" && (
+          Workbench
+          {activeTab === "workbench" && (
             <span className="bg-primary absolute bottom-0 left-0 h-0.5 w-full rounded-full" />
           )}
         </Link>
@@ -919,8 +919,8 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
         </Link>
       </div>
 
-      {/* Optimizer Tab */}
-      {activeTab === "optimizer" && (
+      {/* Workbench Tab */}
+      {activeTab === "workbench" && (
         <CraftingTab items={allItems} blades={blades} armor={armor} />
       )}
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -77,7 +77,7 @@ import { Route as AreasIdRouteImport } from './routes/areas/$id'
 import { Route as AccessoriesIdRouteImport } from './routes/accessories/$id'
 import { Route as InventoryInventoryIdRouteRouteImport } from './routes/inventory/$inventoryId/route'
 import { Route as InventoryInventoryIdIndexRouteImport } from './routes/inventory/$inventoryId/index'
-import { Route as InventoryInventoryIdOptimizerRouteImport } from './routes/inventory/$inventoryId/optimizer'
+import { Route as InventoryInventoryIdWorkbenchRouteImport } from './routes/inventory/$inventoryId/workbench'
 import { Route as InventoryInventoryIdLoadoutRouteImport } from './routes/inventory/$inventoryId/loadout'
 import { Route as InventoryInventoryIdEquipmentRouteImport } from './routes/inventory/$inventoryId/equipment'
 
@@ -423,10 +423,10 @@ const InventoryInventoryIdIndexRoute =
     path: '/',
     getParentRoute: () => InventoryInventoryIdRouteRoute,
   } as any)
-const InventoryInventoryIdOptimizerRoute =
-  InventoryInventoryIdOptimizerRouteImport.update({
-    id: '/optimizer',
-    path: '/optimizer',
+const InventoryInventoryIdWorkbenchRoute =
+  InventoryInventoryIdWorkbenchRouteImport.update({
+    id: '/workbench',
+    path: '/workbench',
     getParentRoute: () => InventoryInventoryIdRouteRoute,
   } as any)
 const InventoryInventoryIdLoadoutRoute =
@@ -512,7 +512,7 @@ export interface FileRoutesByFullPath {
   '/workshops/': typeof WorkshopsIndexRoute
   '/inventory/$inventoryId/equipment': typeof InventoryInventoryIdEquipmentRoute
   '/inventory/$inventoryId/loadout': typeof InventoryInventoryIdLoadoutRoute
-  '/inventory/$inventoryId/optimizer': typeof InventoryInventoryIdOptimizerRoute
+  '/inventory/$inventoryId/workbench': typeof InventoryInventoryIdWorkbenchRoute
   '/inventory/$inventoryId/': typeof InventoryInventoryIdIndexRoute
 }
 export interface FileRoutesByTo {
@@ -563,7 +563,7 @@ export interface FileRoutesByTo {
   '/workshops': typeof WorkshopsIndexRoute
   '/inventory/$inventoryId/equipment': typeof InventoryInventoryIdEquipmentRoute
   '/inventory/$inventoryId/loadout': typeof InventoryInventoryIdLoadoutRoute
-  '/inventory/$inventoryId/optimizer': typeof InventoryInventoryIdOptimizerRoute
+  '/inventory/$inventoryId/workbench': typeof InventoryInventoryIdWorkbenchRoute
   '/inventory/$inventoryId': typeof InventoryInventoryIdIndexRoute
 }
 export interface FileRoutesById {
@@ -637,7 +637,7 @@ export interface FileRoutesById {
   '/workshops/': typeof WorkshopsIndexRoute
   '/inventory/$inventoryId/equipment': typeof InventoryInventoryIdEquipmentRoute
   '/inventory/$inventoryId/loadout': typeof InventoryInventoryIdLoadoutRoute
-  '/inventory/$inventoryId/optimizer': typeof InventoryInventoryIdOptimizerRoute
+  '/inventory/$inventoryId/workbench': typeof InventoryInventoryIdWorkbenchRoute
   '/inventory/$inventoryId/': typeof InventoryInventoryIdIndexRoute
 }
 export interface FileRouteTypes {
@@ -712,7 +712,7 @@ export interface FileRouteTypes {
     | '/workshops/'
     | '/inventory/$inventoryId/equipment'
     | '/inventory/$inventoryId/loadout'
-    | '/inventory/$inventoryId/optimizer'
+    | '/inventory/$inventoryId/workbench'
     | '/inventory/$inventoryId/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -763,7 +763,7 @@ export interface FileRouteTypes {
     | '/workshops'
     | '/inventory/$inventoryId/equipment'
     | '/inventory/$inventoryId/loadout'
-    | '/inventory/$inventoryId/optimizer'
+    | '/inventory/$inventoryId/workbench'
     | '/inventory/$inventoryId'
   id:
     | '__root__'
@@ -836,7 +836,7 @@ export interface FileRouteTypes {
     | '/workshops/'
     | '/inventory/$inventoryId/equipment'
     | '/inventory/$inventoryId/loadout'
-    | '/inventory/$inventoryId/optimizer'
+    | '/inventory/$inventoryId/workbench'
     | '/inventory/$inventoryId/'
   fileRoutesById: FileRoutesById
 }
@@ -1346,11 +1346,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InventoryInventoryIdIndexRouteImport
       parentRoute: typeof InventoryInventoryIdRouteRoute
     }
-    '/inventory/$inventoryId/optimizer': {
-      id: '/inventory/$inventoryId/optimizer'
-      path: '/optimizer'
-      fullPath: '/inventory/$inventoryId/optimizer'
-      preLoaderRoute: typeof InventoryInventoryIdOptimizerRouteImport
+    '/inventory/$inventoryId/workbench': {
+      id: '/inventory/$inventoryId/workbench'
+      path: '/workbench'
+      fullPath: '/inventory/$inventoryId/workbench'
+      preLoaderRoute: typeof InventoryInventoryIdWorkbenchRouteImport
       parentRoute: typeof InventoryInventoryIdRouteRoute
     }
     '/inventory/$inventoryId/loadout': {
@@ -1564,7 +1564,7 @@ const GripsRouteRouteWithChildren = GripsRouteRoute._addFileChildren(
 interface InventoryInventoryIdRouteRouteChildren {
   InventoryInventoryIdEquipmentRoute: typeof InventoryInventoryIdEquipmentRoute
   InventoryInventoryIdLoadoutRoute: typeof InventoryInventoryIdLoadoutRoute
-  InventoryInventoryIdOptimizerRoute: typeof InventoryInventoryIdOptimizerRoute
+  InventoryInventoryIdWorkbenchRoute: typeof InventoryInventoryIdWorkbenchRoute
   InventoryInventoryIdIndexRoute: typeof InventoryInventoryIdIndexRoute
 }
 
@@ -1572,7 +1572,7 @@ const InventoryInventoryIdRouteRouteChildren: InventoryInventoryIdRouteRouteChil
   {
     InventoryInventoryIdEquipmentRoute: InventoryInventoryIdEquipmentRoute,
     InventoryInventoryIdLoadoutRoute: InventoryInventoryIdLoadoutRoute,
-    InventoryInventoryIdOptimizerRoute: InventoryInventoryIdOptimizerRoute,
+    InventoryInventoryIdWorkbenchRoute: InventoryInventoryIdWorkbenchRoute,
     InventoryInventoryIdIndexRoute: InventoryInventoryIdIndexRoute,
   }
 

--- a/src/routes/inventory/$inventoryId/workbench.tsx
+++ b/src/routes/inventory/$inventoryId/workbench.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-export const Route = createFileRoute("/inventory/$inventoryId/optimizer")({
+export const Route = createFileRoute("/inventory/$inventoryId/workbench")({
   component: () => null,
 })


### PR DESCRIPTION
## Summary
- Renamed the inventory "Optimizer" tab to "Workbench" across route file, tab label, and all internal references
- Updated CLAUDE.md to reflect the new route name

Closes #105