### PR TITLE
fix: prune unchained steps from multi-step crafting paths

### DIFF
--- a/src/lib/crafting-optimizer.test.ts
+++ b/src/lib/crafting-optimizer.test.ts
@@ -244,6 +244,54 @@ describe("findCraftingPaths (forward search)", () => {
     expect(paths).toHaveLength(0)
   })
 
+  it("prunes unchained steps from multi-step paths", () => {
+    // Add a Sword recipe so we can create a disconnected path scenario
+    const extraRecipes: CraftingRecipe[] = [
+      ...recipes,
+      {
+        id: 10,
+        category: "blade",
+        sub_category: "Axe_Axe",
+        input_1: "Francisca",
+        input_2: "Francisca",
+        result: "Tabarzin",
+        tier_change: 1,
+        has_swap: false,
+      },
+    ]
+    const index = buildRecipeIndex(extraRecipes, materialRecipes)
+
+    // Inventory has 2 pairs that can each make a Francisca, plus an extra
+    // Hand Axe that can combine with Francisca to make Tabarzin.
+    // The BFS might find: step 1: HandAxe(3)+BattleAxe(4)→Francisca,
+    // step 2: HandAxe(1)+BattleAxe(2)→Francisca, then Francisca+HandAxe→Tabarzin
+    // But the disconnected step should be pruned.
+    const items: CraftableItem[] = [
+      makeItem(1, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(2, "Battle Axe", "Axe / Mace", "Iron"),
+      makeItem(3, "Hand Axe", "Axe / Mace", "Iron"),
+      makeItem(4, "Battle Axe", "Axe / Mace", "Iron"),
+    ]
+
+    const paths = findCraftingPaths(
+      { name: "Tabarzin", material: null },
+      items,
+      index
+    )
+
+    // All paths should have only chained steps — no step's result should
+    // be unused by a later step
+    for (const path of paths) {
+      for (let i = 0; i < path.steps.length - 1; i++) {
+        const resultId = path.steps[i].result.id
+        const usedLater = path.steps
+          .slice(i + 1)
+          .some((s) => s.input1.id === resultId || s.input2.id === resultId)
+        expect(usedLater).toBe(true)
+      }
+    }
+  })
+
   it("ranks shorter paths higher", () => {
     const index = buildRecipeIndex(recipes, materialRecipes)
     const items: CraftableItem[] = [

--- a/src/lib/crafting-optimizer.ts
+++ b/src/lib/crafting-optimizer.ts
@@ -212,6 +212,29 @@ export function inventoryToCraftables(
 
 let syntheticIdCounter = -1
 
+/**
+ * Remove steps whose results are never consumed by a later step.
+ * Keeps only the connected chain leading to the final result.
+ */
+function pruneUnchainedSteps(steps: CraftingStep[]): CraftingStep[] {
+  if (steps.length <= 1) return steps
+
+  // Walk backwards: collect IDs that are needed as inputs
+  const needed = new Set<number>()
+  for (let i = steps.length - 1; i >= 0; i--) {
+    const step = steps[i]
+    // The final step is always kept; earlier steps are kept only if
+    // their result ID is needed as an input by a later step.
+    if (i < steps.length - 1 && !needed.has(step.result.id)) continue
+    needed.add(step.input1.id)
+    needed.add(step.input2.id)
+  }
+
+  return steps.filter(
+    (step, i) => i === steps.length - 1 || needed.has(step.result.id)
+  )
+}
+
 export function findCraftingPaths(
   target: { name: string; material: string | null },
   craftables: CraftableItem[],
@@ -326,11 +349,12 @@ export function findCraftingPaths(
               !target.material || resultItem.material === target.material
 
             if (nameMatch && materialMatch) {
+              const chained = pruneUnchainedSteps(newSteps)
               paths.push({
-                steps: newSteps,
+                steps: chained,
                 result: resultItem,
                 consumedItems: newConsumed,
-                score: scorePath(newSteps, newConsumed, resultItem),
+                score: scorePath(chained, newConsumed, resultItem),
               })
               continue
             }
@@ -394,11 +418,12 @@ export function findCraftingPaths(
                   !target.material || swapResult.material === target.material
 
                 if (swapNameMatch && swapMatMatch) {
+                  const chained = pruneUnchainedSteps(swapSteps)
                   paths.push({
-                    steps: swapSteps,
+                    steps: chained,
                     result: swapResult,
                     consumedItems: swapConsumed,
-                    score: scorePath(swapSteps, swapConsumed, swapResult),
+                    score: scorePath(chained, swapConsumed, swapResult),
                   })
                 }
               }


### PR DESCRIPTION
## Summary
- The BFS optimizer could produce multi-step paths where an intermediate step's result was never consumed by a later step (e.g., step 1 creates a Shamshir that step 2 completely ignores)
- Added `pruneUnchainedSteps()` that walks backwards through the step chain and removes steps whose results aren't used as inputs to any later step
- Added a test verifying all paths have properly chained steps

## Test plan
- [ ] Import a save with multiple blades and run the workbench — verify no expanded results show disconnected steps
- [ ] Try the Hagane Baselard case from the original issue screenshot

Closes #122