### PR TITLE
feat: persist inventory tab selections in URL search params

### DIFF
--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -116,16 +116,37 @@ interface CraftingTabProps {
   items: InventoryItem[]
   blades: Blade[]
   armor: Armor[]
+  searchParams: {
+    wcat?: string
+    target?: string
+    tmat?: string
+    depth?: number
+  }
+  updateSearch: (updates: Record<string, string | number | undefined>) => void
 }
 
 // ── Main component ────────────────────────────────────────────────────
 
-export function CraftingTab({ items, blades, armor }: CraftingTabProps) {
-  // Controls
-  const [forwardCategory, setForwardCategory] = useState<Category | null>(null)
-  const [targetItem, setTargetItem] = useState<string | null>(null)
-  const [targetMaterial, setTargetMaterial] = useState<string | null>(null)
-  const [searchDepth, setSearchDepth] = useState<number>(1)
+export function CraftingTab({
+  items,
+  blades,
+  armor,
+  searchParams,
+  updateSearch,
+}: CraftingTabProps) {
+  // Controls — backed by URL search params
+  const forwardCategory = (searchParams.wcat as Category) ?? null
+  const setForwardCategory = (v: Category | null) =>
+    updateSearch({ wcat: v ?? undefined, target: undefined, tmat: undefined })
+  const targetItem = searchParams.target ?? null
+  const setTargetItem = (v: string | null) =>
+    updateSearch({ target: v ?? undefined, wcat: undefined })
+  const targetMaterial = searchParams.tmat ?? null
+  const setTargetMaterial = (v: string | null) =>
+    updateSearch({ tmat: v ?? undefined })
+  const searchDepth = searchParams.depth ?? 1
+  const setSearchDepth = (v: number) =>
+    updateSearch({ depth: v === 1 ? undefined : v })
   const [includeEquipped, setIncludeEquipped] = useState(true)
   const [includeBag, setIncludeBag] = useState(true)
   const [includeContainer, setIncludeContainer] = useState(true)

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -11,7 +11,12 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Link, useMatchRoute, useParams } from "@tanstack/react-router"
+import {
+  getRouteApi,
+  Link,
+  useMatchRoute,
+  useParams,
+} from "@tanstack/react-router"
 import {
   ArrowDownAZ,
   ArrowDownWideNarrow,
@@ -139,9 +144,28 @@ export function InventoryDetailPage() {
 
 type BagSort = "equipped" | "added" | "name"
 
+const inventoryRouteApi = getRouteApi("/inventory/$inventoryId")
+
 function InventoryDetail({ inventoryId }: { inventoryId: number }) {
   const queryClient = useQueryClient()
   const matchRoute = useMatchRoute()
+  const search = inventoryRouteApi.useSearch()
+  const navigate = inventoryRouteApi.useNavigate()
+  const updateSearch = useCallback(
+    (updates: Record<string, string | number | undefined>) =>
+      navigate({
+        search: (prev: Record<string, unknown>) => {
+          const next = { ...prev, ...updates }
+          for (const key of Object.keys(next)) {
+            if (next[key] === undefined || next[key] === "") delete next[key]
+          }
+          return next
+        },
+        replace: true,
+        resetScroll: false,
+      }),
+    [navigate]
+  )
   const activeTab = matchRoute({
     to: "/inventory/$inventoryId/loadout",
     params: { inventoryId: String(inventoryId) },
@@ -156,8 +180,12 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
   const [editingSlot, setEditingSlot] = useState<SlotConfig | null>(null)
   const [editingBagItem, setEditingBagItem] = useState(false)
   const [bagSearch, setBagSearch] = useState("")
-  const [bagSort, setBagSort] = useState<BagSort>("equipped")
-  const [bagCategory, setBagCategory] = useState("all")
+  const bagSort = (search.sort as BagSort) ?? "equipped"
+  const setBagSort = (v: BagSort) =>
+    updateSearch({ sort: v === "equipped" ? undefined : v })
+  const bagCategory = search.cat ?? "all"
+  const setBagCategory = (v: string) =>
+    updateSearch({ cat: v === "all" ? undefined : v })
 
   const { data: inventory, isLoading } = useQuery({
     queryKey: ["inventory", inventoryId],
@@ -921,7 +949,13 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
 
       {/* Workbench Tab */}
       {activeTab === "workbench" && (
-        <CraftingTab items={allItems} blades={blades} armor={armor} />
+        <CraftingTab
+          items={allItems}
+          blades={blades}
+          armor={armor}
+          searchParams={search}
+          updateSearch={updateSearch}
+        />
       )}
 
       {/* Loadout Tab */}
@@ -940,6 +974,8 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
                 }
               : undefined
           }
+          searchParams={search}
+          updateSearch={updateSearch}
         />
       )}
 
@@ -1000,10 +1036,10 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
                 size="sm"
                 className="shrink-0"
                 onClick={() =>
-                  setBagSort((s) =>
-                    s === "equipped"
+                  setBagSort(
+                    bagSort === "equipped"
                       ? "added"
-                      : s === "added"
+                      : bagSort === "added"
                         ? "name"
                         : "equipped"
                   )

--- a/src/pages/inventory/loadout-tab.tsx
+++ b/src/pages/inventory/loadout-tab.tsx
@@ -43,13 +43,28 @@ interface LoadoutTabProps {
   items: InventoryItem[]
   inventoryId: number
   baseStats?: BaseStats
+  searchParams: {
+    enemy?: string
+    lmode?: string
+  }
+  updateSearch: (updates: Record<string, string | number | undefined>) => void
 }
 
 // ── Main component ──────────────────────────────────────────────────
 
-export function LoadoutTab({ items, inventoryId, baseStats }: LoadoutTabProps) {
-  const [selectedEnemy, setSelectedEnemy] = useState<string | null>(null)
-  const [mode, setMode] = useState<Mode>("full")
+export function LoadoutTab({
+  items,
+  inventoryId,
+  baseStats,
+  searchParams,
+  updateSearch,
+}: LoadoutTabProps) {
+  const selectedEnemy = searchParams.enemy ?? null
+  const setSelectedEnemy = (v: string | null) =>
+    updateSearch({ enemy: v ?? undefined })
+  const mode: Mode = (searchParams.lmode as Mode) ?? "full"
+  const setMode = (v: Mode) =>
+    updateSearch({ lmode: v === "full" ? undefined : v })
   const [includeEquipped, setIncludeEquipped] = useState(true)
   const [includeBag, setIncludeBag] = useState(true)
   const [includeContainer, setIncludeContainer] = useState(true)

--- a/src/routes/inventory/$inventoryId/route.tsx
+++ b/src/routes/inventory/$inventoryId/route.tsx
@@ -1,6 +1,35 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { InventoryDetailPage } from "@/pages/inventory/inventory-detail"
 
+export type InventorySearch = {
+  // Equipment tab
+  sort?: string
+  cat?: string
+  // Workbench tab
+  wcat?: string
+  target?: string
+  tmat?: string
+  depth?: number
+  // Loadout tab
+  enemy?: string
+  lmode?: string
+}
+
 export const Route = createFileRoute("/inventory/$inventoryId")({
   component: InventoryDetailPage,
+  validateSearch: (search: Record<string, unknown>): InventorySearch => ({
+    sort: typeof search.sort === "string" ? search.sort : undefined,
+    cat: typeof search.cat === "string" ? search.cat : undefined,
+    wcat: typeof search.wcat === "string" ? search.wcat : undefined,
+    target: typeof search.target === "string" ? search.target : undefined,
+    tmat: typeof search.tmat === "string" ? search.tmat : undefined,
+    depth:
+      typeof search.depth === "number"
+        ? search.depth
+        : typeof search.depth === "string"
+          ? parseInt(search.depth, 10) || undefined
+          : undefined,
+    enemy: typeof search.enemy === "string" ? search.enemy : undefined,
+    lmode: typeof search.lmode === "string" ? search.lmode : undefined,
+  }),
 })


### PR DESCRIPTION
## Summary
- Added `validateSearch` to the parent inventory route so search params persist across tab switches
- Equipment tab: bag sort order (`sort`), category filter (`cat`)
- Workbench tab: forward category (`wcat`), target item/material (`target`, `tmat`), search depth (`depth`)
- Loadout tab: selected enemy (`enemy`), optimization mode (`lmode`)
- Switching tabs no longer resets the other tab's selections

## Test plan
- [ ] Set filters on Equipment tab, switch to Workbench, switch back — filters should persist
- [ ] Select a target item on Workbench, switch tabs and back — target should persist
- [ ] Select an enemy on Loadout, switch tabs and back — enemy should persist
- [ ] Refresh page — URL params should restore state
- [ ] Check URL updates as selections change

Closes #115
Closes #116