### PR TITLE
feat(ui): add loading skeletons for cold-start and query states

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -39,6 +39,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 
 export interface ColumnFilter {
@@ -179,14 +180,15 @@ export function DataTable<T>({
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="text-muted-foreground py-8 text-center"
-                >
-                  Loading...
-                </TableCell>
-              </TableRow>
+              Array.from({ length: 10 }).map((_, rowIdx) => (
+                <TableRow key={`skeleton-${rowIdx}`}>
+                  {columns.map((_, colIdx) => (
+                    <TableCell key={colIdx} className="px-4 py-3">
+                      <Skeleton className="h-4 w-full" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
             ) : table.getRowModel().rows.length === 0 ? (
               <TableRow>
                 <TableCell

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("bg-muted animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import { RootErrorComponent } from "./components/error-boundary"
 import { NotFound } from "./components/not-found"
 import { AuthProvider, useAuth } from "./lib/auth"
 import { AnalyticsProvider, createAnalyticsBackend } from "./lib/analytics"
+import { Skeleton } from "./components/ui/skeleton"
 import { routeTree } from "./routeTree.gen"
 
 const queryClient = new QueryClient({
@@ -62,9 +63,43 @@ declare module "@tanstack/react-query" {
   }
 }
 
+function AppShellSkeleton() {
+  return (
+    <>
+      <nav className="border-border/50 bg-background/80 fixed top-0 z-50 w-full border-b backdrop-blur-sm">
+        <div className="flex h-14 items-center justify-between px-4">
+          <div className="flex items-center gap-6">
+            <div className="w-8" />
+            <span className="font-sans text-lg tracking-wide">
+              Vagrant Story
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-8 rounded-md" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+          </div>
+        </div>
+      </nav>
+      <div className="relative flex min-h-screen pt-14">
+        <div className="mx-auto w-full max-w-6xl space-y-8 px-6 pt-16">
+          <div className="space-y-4 text-center">
+            <Skeleton className="mx-auto h-14 w-96" />
+            <Skeleton className="mx-auto h-5 w-[32rem] max-w-full" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
 function App() {
   const auth = useAuth()
-  if (auth.isLoading) return null
+  if (auth.isLoading) return <AppShellSkeleton />
   return <RouterProvider router={router} context={{ auth }} />
 }
 

--- a/src/pages/crafting/materials-page.tsx
+++ b/src/pages/crafting/materials-page.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
 import { gameApi, type MaterialRecipe } from "@/lib/game-api"
 import { cn } from "@/lib/utils"
 
@@ -272,9 +273,7 @@ export function CraftingMaterialsPage() {
               Cell = result material from combining Slot 1 and Slot 2
             </p>
             {isLoading ? (
-              <p className="text-muted-foreground py-8 text-center text-sm">
-                Loading...
-              </p>
+              <Skeleton className="h-64 w-full" />
             ) : grid ? (
               <MaterialGrid
                 grid={grid}

--- a/src/pages/inventory/import-page.tsx
+++ b/src/pages/inventory/import-page.tsx
@@ -17,6 +17,7 @@ import { useAnalytics } from "@/lib/analytics"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Select,
   SelectContent,
@@ -110,8 +111,10 @@ export function ImportPage() {
 
   if (auth.isLoading) {
     return (
-      <div className="text-muted-foreground py-20 text-center text-sm">
-        Loading...
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 py-8">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-96 max-w-full" />
+        <Skeleton className="h-40 w-full" />
       </div>
     )
   }

--- a/src/pages/inventory/inventory-list.tsx
+++ b/src/pages/inventory/inventory-list.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
 import { ItemIcon } from "@/components/item-icon"
 import { useAuth } from "@/lib/auth"
 import { loginUrl } from "@/lib/config"
@@ -34,11 +35,7 @@ export function InventoryListPage() {
   const auth = useAuth()
 
   if (auth.isLoading) {
-    return (
-      <div className="text-muted-foreground py-20 text-center text-sm">
-        Loading...
-      </div>
-    )
+    return <InventoryListSkeleton />
   }
 
   if (!auth.isAuthenticated) {
@@ -55,6 +52,25 @@ export function InventoryListPage() {
   }
 
   return <InventoryList />
+}
+
+function InventoryListSkeleton() {
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-5 w-28" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-36" />
+          <Skeleton className="h-8 w-28" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full" />
+        ))}
+      </div>
+    </div>
+  )
 }
 
 function InventoryList() {
@@ -116,11 +132,7 @@ function InventoryList() {
   }, [inventories, search, sortKey])
 
   if (isLoading) {
-    return (
-      <div className="text-muted-foreground py-10 text-center text-sm">
-        Loading inventories...
-      </div>
-    )
+    return <InventoryListSkeleton />
   }
 
   if (error) {

--- a/src/pages/materials/materials-page.tsx
+++ b/src/pages/materials/materials-page.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { ItemIcon } from "@/components/item-icon"
 import { MaterialBadge } from "@/components/stat-display"
+import { Skeleton } from "@/components/ui/skeleton"
 import { gameApi, type Material } from "@/lib/game-api"
 import { cn } from "@/lib/utils"
 
@@ -47,7 +48,11 @@ export function MaterialsPage() {
       </div>
 
       {isLoading ? (
-        <p className="text-muted-foreground py-8 text-center">Loading...</p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 w-full" />
+          ))}
+        </div>
       ) : (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {materials.map((m) => (


### PR DESCRIPTION
## Summary

Cloud Run cold starts on the vagrant-story-api can take 5–15s, and until now the app showed **literal blank screens** during auth bootstrap and initial data fetches. This PR replaces \`return null\` / \`"Loading..."\` placeholders with shaped skeleton components so users see structure immediately.

### The biggest win: \`main.tsx\`

Before: \`if (auth.isLoading) return null\` — blank white screen until \`/auth/me\` responded.
After: \`<AppShellSkeleton />\` — users immediately see the nav bar, page title skeleton, and a grid of card skeletons that roughly match the homepage layout.

### Changes

| File | What changed |
|------|-------------|
| **New**: \`src/components/ui/skeleton.tsx\` | shadcn Skeleton primitive — animated pulse |
| \`src/main.tsx\` | Replace \`return null\` with \`<AppShellSkeleton />\` — nav + title + card-grid placeholders |
| \`src/components/data-table.tsx\` | Replace centered "Loading..." cell with **10 skeleton rows matching the column count**. Improves the loading state on ~20 pages that pipe \`isLoading\` through to \`DataTable\` (blades, armor, gems, bestiary, chests, break-arts, etc.) |
| \`src/pages/inventory/inventory-list.tsx\` | Shared \`InventoryListSkeleton\` used for both auth-loading and query-loading paths (replaces 2× "Loading..." strings) |
| \`src/pages/inventory/import-page.tsx\` | Skeleton block shape for the auth-loading state |
| \`src/pages/materials/materials-page.tsx\` | Skeleton grid (8 card placeholders) instead of centered "Loading..." |
| \`src/pages/crafting/materials-page.tsx\` | Skeleton block for the combination grid card |

### Deliberately not touched

- **\`src/components/item-drop-locations.tsx\`** — the \`if (isLoading) return null\` there has legitimate empty-state semantics. That component also returns null when \`drops.length === 0\`, so a skeleton that disappeared on empty data would be worse UX than just hiding the section until we know it has content.
- **\`src/pages/home/home-page.tsx\`** — shows \`{card.count} items\` where \`count\` defaults to \`0\` during loading. This is a minor accuracy issue (shows "0 items" briefly) but not a blank-screen bug. Could be addressed in a follow-up by tracking per-query loading state if it matters.

## Cold start still vs min=1

This is the non-cost fix. If you decide the skeleton UX still isn't good enough for the cold start gap, flipping the vagrant-story-api Cloud Run service to \`--min-instances 1\` is the direct-cost alternative (~$5-15/mo for db-f1-micro). The skeletons here are valuable regardless since they also cover normal cache-cold query loads, not just cold starts.

## Test plan

- [x] \`pnpm tsc --noEmit\` passes
- [x] \`pnpm test:run\` — 16/16 tests pass
- [x] \`pnpm lint\` — 0 errors (42 pre-existing warnings)
- [x] \`pnpm build\` passes (via pre-commit hook)
- [ ] CI passes
- [ ] **Deploy preview**: hard-refresh the homepage in a throttled network tab — should see the AppShell skeleton → real home page transition instead of a blank screen
- [ ] **Deploy preview**: visit any database page (e.g. \`/blades\`) — should see 10 skeleton rows instead of "Loading..." text
- [ ] **Deploy preview**: visit \`/materials\` — should see 8 skeleton cards instead of "Loading..." text
- [ ] **Deploy preview**: visit \`/inventory\` while logged out, sign in, and watch the auth-loading transition