### PR TITLE
fix(inventory): keep active tab on select change & restore import icons

### DIFF
--- a/src/pages/inventory/import-page.tsx
+++ b/src/pages/inventory/import-page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react"
-import { useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
+import { gameApi } from "@/lib/game-api"
 import {
   AlertTriangle,
   ArrowLeft,
@@ -76,16 +77,7 @@ function generateSlotName(slot: ParsedSaveSlot): string {
   return parts.join(" — ")
 }
 
-// ── Display helpers using ITEMNAME_MAP ───────────────────────────────
-
-/** Item type category for display grouping. Maps item_type to a UI category. */
-const ITEM_TYPE_CATEGORY: Record<string, string> = {
-  blade: "Blade",
-  grip: "Grip",
-  armor: "Armor",
-  gem: "Gem",
-  consumable: "Consumable",
-}
+// ── Display helpers ──────────────────────────────────────────────────
 
 /** Reverse lookup: field_name → display name, built once from ITEMNAME_MAP. */
 const FIELD_NAME_TO_DISPLAY = new Map<string, string>()
@@ -100,9 +92,7 @@ function getDisplayName(item: GameSaveImportItem): string {
   )
 }
 
-function getDisplayType(item: GameSaveImportItem): string {
-  return ITEM_TYPE_CATEGORY[item.item_type] ?? item.item_type
-}
+type GetDisplayType = (item: GameSaveImportItem) => string
 
 // ── Main export ──────────────────────────────────────────────────────
 
@@ -144,6 +134,39 @@ function ImportFlow() {
   const [error, setError] = useState<string | null>(null)
   const [importProgress, setImportProgress] = useState(0)
   const [importTotal, setImportTotal] = useState(0)
+
+  // Game data — shared React Query cache with the rest of the app.
+  // Needed so preview icons can resolve specific subtypes (Sword, Helm, …)
+  // instead of the generic buckets ItemIcon has no key for.
+  const { data: blades = [] } = useQuery({
+    queryKey: ["blades"],
+    queryFn: gameApi.blades,
+  })
+  const { data: armor = [] } = useQuery({
+    queryKey: ["armor"],
+    queryFn: gameApi.armor,
+  })
+  const { data: grips = [] } = useQuery({
+    queryKey: ["grips"],
+    queryFn: gameApi.grips,
+  })
+
+  const getDisplayType = useMemo<GetDisplayType>(() => {
+    const bladeType = new Map(blades.map((b) => [b.field_name, b.blade_type]))
+    const armorType = new Map(armor.map((a) => [a.field_name, a.armor_type]))
+    const gripType = new Map(grips.map((g) => [g.field_name, g.grip_type]))
+    return (item) => {
+      if (item.item_type === "blade")
+        return bladeType.get(item.field_name) ?? "Blade"
+      if (item.item_type === "armor")
+        return armorType.get(item.field_name) ?? "Armor"
+      if (item.item_type === "grip")
+        return gripType.get(item.field_name) ?? "Grip"
+      if (item.item_type === "gem") return "Gem"
+      if (item.item_type === "consumable") return "Consumable"
+      return item.item_type
+    }
+  }, [blades, armor, grips])
 
   // ── File handling ───────────────────────────────────────────────────
 
@@ -319,6 +342,7 @@ function ImportFlow() {
           }}
           selectedCount={selectedSlots.length}
           buildPreviewItems={buildPreviewItems}
+          getDisplayType={getDisplayType}
         />
       )}
 
@@ -423,6 +447,7 @@ function PreviewPhase({
   onBack,
   selectedCount,
   buildPreviewItems,
+  getDisplayType,
 }: {
   slots: SlotState[]
   onToggleSelected: (index: number) => void
@@ -432,6 +457,7 @@ function PreviewPhase({
   onBack: () => void
   selectedCount: number
   buildPreviewItems: (slot: ParsedSaveSlot) => GameSaveImportItem[]
+  getDisplayType: GetDisplayType
 }) {
   return (
     <div className="space-y-4">
@@ -449,6 +475,7 @@ function PreviewPhase({
           onToggleExpanded={onToggleExpanded}
           onUpdateName={onUpdateName}
           buildPreviewItems={buildPreviewItems}
+          getDisplayType={getDisplayType}
         />
       ))}
 
@@ -582,6 +609,7 @@ function SlotCard({
   onToggleExpanded,
   onUpdateName,
   buildPreviewItems,
+  getDisplayType,
 }: {
   state: SlotState
   index: number
@@ -589,6 +617,7 @@ function SlotCard({
   onToggleExpanded: (index: number) => void
   onUpdateName: (index: number, name: string) => void
   buildPreviewItems: (slot: ParsedSaveSlot) => GameSaveImportItem[]
+  getDisplayType: GetDisplayType
 }) {
   const { slot, name, selected, expanded } = state
   const disabled = !slot.checksumValid
@@ -607,29 +636,32 @@ function SlotCard({
   const equippedItems = bagItems.filter((i) => i.equip_slot)
 
   // Build category counts
-  const getCategoryCounts = useCallback((items: GameSaveImportItem[]) => {
-    const counts = new Map<string, number>()
-    for (const item of items) {
-      const category =
-        DISPLAY_TYPE_TO_CATEGORY[getDisplayType(item)] ?? getDisplayType(item)
-      counts.set(category, (counts.get(category) ?? 0) + 1)
-    }
-    const order = [
-      "Blade",
-      "Grip",
-      "Shield",
-      "Helm",
-      "Body",
-      "Leg",
-      "Arm",
-      "Accessory",
-      "Gem",
-      "Consumable",
-    ]
-    return order
-      .filter((c) => counts.has(c))
-      .map((c) => ({ label: c, count: counts.get(c)! }))
-  }, [])
+  const getCategoryCounts = useCallback(
+    (items: GameSaveImportItem[]) => {
+      const counts = new Map<string, number>()
+      for (const item of items) {
+        const category =
+          DISPLAY_TYPE_TO_CATEGORY[getDisplayType(item)] ?? getDisplayType(item)
+        counts.set(category, (counts.get(category) ?? 0) + 1)
+      }
+      const order = [
+        "Blade",
+        "Grip",
+        "Shield",
+        "Helm",
+        "Body",
+        "Leg",
+        "Arm",
+        "Accessory",
+        "Gem",
+        "Consumable",
+      ]
+      return order
+        .filter((c) => counts.has(c))
+        .map((c) => ({ label: c, count: counts.get(c)! }))
+    },
+    [getDisplayType]
+  )
 
   const bagCategories = useMemo(
     () => getCategoryCounts(bagItems),
@@ -649,7 +681,7 @@ function SlotCard({
         return cat === category
       })
     },
-    []
+    [getDisplayType]
   )
 
   const hpPct = slot.maxHp > 0 ? (slot.hp / slot.maxHp) * 100 : 0

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -15,6 +15,7 @@ import {
   getRouteApi,
   Link,
   useMatchRoute,
+  useNavigate,
   useParams,
 } from "@tanstack/react-router"
 import {
@@ -150,22 +151,7 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
   const queryClient = useQueryClient()
   const matchRoute = useMatchRoute()
   const search = inventoryRouteApi.useSearch()
-  const navigate = inventoryRouteApi.useNavigate()
-  const updateSearch = useCallback(
-    (updates: Record<string, string | number | undefined>) =>
-      navigate({
-        search: (prev: Record<string, unknown>) => {
-          const next = { ...prev, ...updates }
-          for (const key of Object.keys(next)) {
-            if (next[key] === undefined || next[key] === "") delete next[key]
-          }
-          return next
-        },
-        replace: true,
-        resetScroll: false,
-      }),
-    [navigate]
-  )
+  const navigate = useNavigate()
   const activeTab = matchRoute({
     to: "/inventory/$inventoryId/loadout",
     params: { inventoryId: String(inventoryId) },
@@ -177,6 +163,33 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
         })
       ? "workbench"
       : "equipment"
+  // Route search-param updates back to the active subroute explicitly.
+  // A route-bound navigate on the parent would resolve to /inventory/$inventoryId,
+  // whose index redirects to /equipment — silently kicking users off workbench/loadout.
+  const updateSearch = useCallback(
+    (updates: Record<string, string | number | undefined>) => {
+      const to =
+        activeTab === "loadout"
+          ? "/inventory/$inventoryId/loadout"
+          : activeTab === "workbench"
+            ? "/inventory/$inventoryId/workbench"
+            : "/inventory/$inventoryId/equipment"
+      navigate({
+        to,
+        params: { inventoryId: String(inventoryId) },
+        search: (prev) => {
+          const next: Record<string, unknown> = { ...prev, ...updates }
+          for (const key of Object.keys(next)) {
+            if (next[key] === undefined || next[key] === "") delete next[key]
+          }
+          return next
+        },
+        replace: true,
+        resetScroll: false,
+      })
+    },
+    [navigate, activeTab, inventoryId]
+  )
   const [editingSlot, setEditingSlot] = useState<SlotConfig | null>(null)
   const [editingBagItem, setEditingBagItem] = useState(false)
   const [bagSearch, setBagSearch] = useState("")


### PR DESCRIPTION
## Summary
- **Fix tab reset on workbench/loadout Selects.** The inventory detail page's `updateSearch` was calling a route-bound `useNavigate()` on `/inventory/\$inventoryId`. With no explicit `to`, the parent path was resolved — which falls through the index route's `<Navigate to=".../equipment" replace />`. Every Select change in workbench/loadout kicked users back to equipment. Now `updateSearch` routes search-param updates to the active subroute explicitly.
- **Fix missing icons in save import preview.** `import-page.tsx`'s `getDisplayType` collapsed items into broad buckets (`"Blade"`, `"Armor"`) that `ItemIcon`'s `ICON_MAP` has no key for, so icons silently rendered the empty-div fallback. The preview now fetches blades/armor/grips via React Query (shared cache with the rest of the app) and resolves `field_name → specific subtype` (`"Sword"`, `"Helm"`, …) — matching how `inventory-detail.tsx` already derives display types.

## Test plan
- [ ] Open an inventory, switch to the **Workbench** tab, change any Select (category / target / target material / depth). Tab stays on Workbench.
- [ ] Same for the **Loadout** tab (enemy, mode).
- [ ] Equipment tab Selects continue to work.
- [ ] Navigate to `/inventory/import`, load a memory card file, expand a slot — equipment grid and bag/container rows now display correct icons (swords, helms, etc.) instead of blank boxes.
- [ ] Category filter Selects in the import preview still bucket items correctly.