### PR TITLE
fix(inventory): persist workbench selections on select change

### DIFF
--- a/src/pages/inventory/crafting-tab.tsx
+++ b/src/pages/inventory/crafting-tab.tsx
@@ -140,7 +140,7 @@ export function CraftingTab({
     updateSearch({ wcat: v ?? undefined, target: undefined, tmat: undefined })
   const targetItem = searchParams.target ?? null
   const setTargetItem = (v: string | null) =>
-    updateSearch({ target: v ?? undefined, wcat: undefined })
+    updateSearch({ target: v ?? undefined, wcat: undefined, tmat: undefined })
   const targetMaterial = searchParams.tmat ?? null
   const setTargetMaterial = (v: string | null) =>
     updateSearch({ tmat: v ?? undefined })
@@ -545,9 +545,10 @@ export function CraftingTab({
           <Select
             value={forwardCategory ?? ""}
             onValueChange={(v) => {
+              // setForwardCategory already clears target+tmat in a single URL
+              // write — calling the other setters here would queue additional
+              // navigate()s that race and wipe wcat.
               setForwardCategory(v as Category)
-              setTargetItem(null)
-              setTargetMaterial(null)
               setDiscoverSearched(false)
               setReverseSearched(false)
             }}
@@ -580,9 +581,8 @@ export function CraftingTab({
             items={allPickerItems}
             value={targetItem}
             onSelect={(name) => {
+              // setTargetItem already clears wcat+tmat in a single URL write.
               setTargetItem(name)
-              setForwardCategory(null)
-              setTargetMaterial(null)
               setDiscoverSearched(false)
               setReverseSearched(false)
             }}


### PR DESCRIPTION
## Summary
Follow-up to #137. Picking a category or target item in the workbench tab didn't persist — the URL search params ended up empty after each click.

**Root cause:** the onValueChange handlers called multiple mutually exclusive setters in sequence (`setForwardCategory(v)` + `setTargetItem(null)` + `setTargetMaterial(null)`). Each setter fires its own \`navigate()\` that races with the others. The second setter's \`wcat: undefined\` would wipe the \`wcat\` the first setter had just written, so nothing stuck.

This was latent before #137 — the workbench tab always bounced back to equipment before anyone could see the clobbered params.

**Fix:** rely on each setter's built-in mutual-exclusion clears so exactly one URL write happens per interaction. \`setTargetItem\` now also clears \`tmat\`, since picking a new target invalidates any previous material pick (preserving the prior intent of the handler's redundant clear).

## Test plan
- [ ] Workbench → pick a category → URL gains \`?wcat=...\`, category dropdown stays populated.
- [ ] Workbench → pick a target item → URL gains \`?target=...\`, selection persists.
- [ ] Pick a category, then pick a target item → \`wcat\` clears, \`target\` is set.
- [ ] Pick a target, then a target material → both persist.
- [ ] Pick a target with an existing material, then switch target → \`tmat\` clears (stale material gone).
- [ ] Depth select still works (single setter, unchanged).
- [ ] Reset button still clears everything.