### PR TITLE
feat(observability): enable sendDefaultPii now that privacy policy covers it

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -15,9 +15,10 @@ export function initSentry(router: SentryRouter) {
     environment: import.meta.env.MODE,
     release: __APP_VERSION__,
 
-    // Kept false until a public privacy policy ships — consistent with the
-    // cookie-free PostHog posture. Flip to true once a privacy page is live.
-    sendDefaultPii: false,
+    // Privacy policy at criticalbit.gg/privacy discloses the data
+    // collected here (IP, headers, URL). Enabled for debuggability now
+    // that users have been given notice.
+    sendDefaultPii: true,
 
     integrations: [
       Sentry.tanstackRouterBrowserTracingIntegration(router),


### PR DESCRIPTION
## Summary
Flips \`sendDefaultPii\` from \`false\` to \`true\` in \`src/lib/sentry.ts\`. This attaches client IP, browser headers, and URL context to frontend error events captured by Sentry, significantly improving debuggability.

**Phase 2, part 3 of 3 (final)** in the Sentry observability rollout.

## Prerequisites (all met)
1. ✅ Privacy policy updated at \`criticalbit.gg/privacy\` with Sentry disclosure — criticalbit-web PR #11 merged as \`8550911\`, live in production (bundle hash verified)
2. ✅ Backend PII flip — vagrant-story-api PR #69 merged as \`1f29563\`, Cloud Run deploy workflow currently running

## What this changes in browser error data

Before (\`sendDefaultPii: false\`):
- Error message, stack trace, file + line
- Breadcrumbs (navigation, clicks, network calls — all sanitized)
- Browser name/version (from user-agent parsing, not the raw header)
- No IP, no raw headers, no cookies, no user

After (\`sendDefaultPii: true\`, this PR):
- Everything above, PLUS:
- Client IP address (resolved server-side by Sentry from the connection)
- Raw request headers including cookies (Sentry strips \`Authorization\` by default)
- URL query strings with their values

All of the above is disclosed in the privacy policy under \"What we collect\" → error diagnostics and \"Third-party services\" → Sentry.

## Test plan
- [x] \`pnpm lint\` passes (0 errors, 84 pre-existing warnings — count grew since last session due to unrelated inventory-page PR merged to main)
- [x] \`pnpm test:run\` passes (16/16)
- [x] \`pnpm build\` passes (1.29s)
- [ ] Post-merge: trigger an error on production (e.g. paste \`throw new Error(\"PII test\")\` in DevTools console on the live site after bundle deploys), verify the resulting event in Sentry shows populated \"User\" and \"Request\" sections with IP + headers

## End of Phase 2
With this PR, Phase 2 of the Sentry follow-up work is complete:
- Phase 1 ✅ Backend release tracking (vagrant-story-api PR #68)
- Phase 2.1 ✅ Privacy policy augmentations (criticalbit-web PR #11)
- Phase 2.2 ✅ Backend PII flip (vagrant-story-api PR #69)
- Phase 2.3 — this PR

Phase 3 (PostHog cross-subdomain cookies + consent banner with centralized storage in auth-api) is a larger design+build effort and will be planned separately.