### PR TITLE
feat: gate PostHog and Sentry replay on explicit user consent

### DIFF
--- a/src/lib/analytics.tsx
+++ b/src/lib/analytics.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo } from "react"
 import posthog from "posthog-js"
+import { readCachedConsent } from "@/lib/consent"
 import { logger } from "@/lib/logger"
 
 // All events from this site are prefixed so they can be filtered out of the
@@ -27,15 +28,22 @@ const defaultBackend: AnalyticsBackend = {
   },
 }
 
+// Tracks whether the user gave analytics consent at page load. Flips to
+// true only after a successful consent-gated init; identify() remains a
+// no-op otherwise so memory-mode sessions never build a person profile.
+let capturingEnabled = false
+
 const posthogBackend: AnalyticsBackend = {
   track(event, properties) {
+    if (!capturingEnabled) return
     posthog.capture(`${EVENT_PREFIX}${event}`, properties)
   },
-  identify() {
-    // Cookie-free mode — do not identify users
+  identify(userId, traits) {
+    if (!capturingEnabled) return
+    posthog.identify(userId, traits)
   },
   page() {
-    // PostHog auto-captures pageviews; no manual call needed
+    // PostHog auto-captures pageviews when capturing is enabled.
   },
 }
 
@@ -44,16 +52,43 @@ export function createAnalyticsBackend(): AnalyticsBackend {
   const host = import.meta.env.VITE_POSTHOG_HOST
   if (!key || !host) return defaultBackend
 
+  const analyticsConsented = readCachedConsent("analytics")
+
+  // cross_subdomain_cookie defaults to true, so when persistence is
+  // "localStorage+cookie" PostHog automatically scopes the cookie to the
+  // eTLD+1 (.criticalbit.gg in prod, localhost in dev). No manual domain
+  // configuration required.
   posthog.init(key, {
     api_host: host,
     defaults: "2026-01-30",
-    persistence: "memory",
+    persistence: analyticsConsented ? "localStorage+cookie" : "memory",
     disable_session_recording: true,
     autocapture: false,
-    capture_pageview: true,
-    capture_pageleave: true,
+    capture_pageview: analyticsConsented,
+    capture_pageleave: analyticsConsented,
   })
+
+  if (analyticsConsented) {
+    posthog.opt_in_capturing()
+    capturingEnabled = true
+  } else {
+    // Belt-and-suspenders: scrub any cookies left over from a prior
+    // session where the user had consented. Safe to call on a fresh
+    // init; it only clears persistence, not in-memory config.
+    posthog.opt_out_capturing()
+    posthog.reset(true)
+    capturingEnabled = false
+  }
+
   return posthogBackend
+}
+
+export function resetAnalytics(): void {
+  try {
+    posthog.reset(true)
+  } catch {
+    // PostHog never initialized (missing env vars) — nothing to reset.
+  }
 }
 
 const AnalyticsContext = createContext<AnalyticsBackend>(defaultBackend)

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -8,6 +8,13 @@ import {
   useState,
 } from "react"
 import { api, setOnUnauthorized } from "@/api/api"
+import { resetAnalytics } from "@/lib/analytics"
+import {
+  clearCachedConsents,
+  fetchConsents,
+  writeCachedConsents,
+  type ConsentsResponse,
+} from "@/lib/consent"
 
 interface AuthContextValue {
   isAuthenticated: boolean
@@ -16,6 +23,7 @@ interface AuthContextValue {
   userId: string | null
   displayName: string | null
   avatarUrl: string | null
+  consents: ConsentsResponse | null
   login: (email: string) => void
   logout: () => Promise<void>
   checkAuth: () => Promise<void>
@@ -31,6 +39,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [userId, setUserId] = useState<string | null>(null)
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
+  const [consents, setConsents] = useState<ConsentsResponse | null>(null)
 
   const clearState = useCallback(() => {
     setIsAuthenticated(false)
@@ -38,6 +47,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUserId(null)
     setDisplayName(null)
     setAvatarUrl(null)
+    setConsents(null)
+    clearCachedConsents()
     queryClient.clear()
   }, [queryClient])
 
@@ -47,6 +58,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } catch {
       // Clear state regardless of fetch success
     }
+    // Wipe PostHog cookies and distinct id alongside the auth session so
+    // a subsequent anonymous visit (or a different user on this device)
+    // does not inherit the previous identity.
+    resetAnalytics()
     clearState()
   }, [clearState])
 
@@ -68,6 +83,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUserId(user.id)
       setDisplayName(user.display_name)
       setAvatarUrl(user.avatar_url)
+      // Consent hydration must not block auth — if the endpoint is down
+      // the user stays logged in and PostHog/Sentry continue using
+      // whatever was cached from the previous successful fetch.
+      try {
+        const response = await fetchConsents()
+        setConsents(response)
+        writeCachedConsents(response)
+      } catch {
+        // Swallow — the cache from a prior session remains authoritative.
+      }
     } catch {
       clearState()
     } finally {
@@ -93,6 +118,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       userId,
       displayName,
       avatarUrl,
+      consents,
       login,
       logout,
       checkAuth,
@@ -104,6 +130,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       userId,
       displayName,
       avatarUrl,
+      consents,
       login,
       logout,
       checkAuth,

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,62 @@
+import { api } from "@/api/api"
+
+// Consent state is authoritative in criticalbit-auth-api's DB. We hydrate
+// it into React state after auth resolves, and we also mirror it to
+// localStorage so boot-time code (PostHog and Sentry init, which run
+// synchronously before React mounts) can read the user's last-known
+// choices without waiting for the network. The one-page-load lag when a
+// user changes consent is intentional and matches the "changes take
+// effect on next reload" UX copy in criticalbit-auth-web.
+
+export const CONSENT_TYPES = ["analytics", "session_replay"] as const
+export type ConsentType = (typeof CONSENT_TYPES)[number]
+
+export interface ConsentEntry {
+  consented: boolean
+  version: string
+  consented_at: string
+  is_stale: boolean
+}
+
+export interface ConsentsResponse {
+  current_policy_version: string
+  consents: Partial<Record<ConsentType, ConsentEntry>>
+}
+
+const CACHE_KEYS: Record<ConsentType, string> = {
+  analytics: "cb_consent_analytics",
+  session_replay: "cb_consent_session_replay",
+}
+
+export async function fetchConsents(): Promise<ConsentsResponse> {
+  return api.get("user/consents").json<ConsentsResponse>()
+}
+
+export function readCachedConsent(type: ConsentType): boolean {
+  try {
+    return window.localStorage.getItem(CACHE_KEYS[type]) === "1"
+  } catch {
+    return false
+  }
+}
+
+export function writeCachedConsents(response: ConsentsResponse): void {
+  try {
+    for (const type of CONSENT_TYPES) {
+      const consented = response.consents[type]?.consented ?? false
+      window.localStorage.setItem(CACHE_KEYS[type], consented ? "1" : "0")
+    }
+  } catch {
+    // localStorage unavailable (private browsing in some browsers) — skip.
+  }
+}
+
+export function clearCachedConsents(): void {
+  try {
+    for (const type of CONSENT_TYPES) {
+      window.localStorage.removeItem(CACHE_KEYS[type])
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/react"
+import { readCachedConsent } from "@/lib/consent"
 
 type SentryRouter = Parameters<
   typeof Sentry.tanstackRouterBrowserTracingIntegration
@@ -9,6 +10,12 @@ let initialized = false
 export function initSentry(router: SentryRouter) {
   const dsn = import.meta.env.VITE_SENTRY_DSN
   if (!dsn) return
+
+  // Session replay is gated on explicit user consent. When consent is
+  // absent the integration is still installed so error-driven replays
+  // keep working (low quota footprint, high debug value per event);
+  // full session sampling only turns on when the user has opted in.
+  const sessionReplayConsented = readCachedConsent("session_replay")
 
   Sentry.init({
     dsn,
@@ -34,11 +41,13 @@ export function initSentry(router: SentryRouter) {
       /^https:\/\/vagrant-story-api\.criticalbit\.gg/,
     ],
 
-    // Project-specific deviation from Sentry's default 0.1 recommendation:
-    // Sentry free tier includes 50 replays/month. Session-rate sampling at 10%
-    // would blow the quota during any traffic burst. Error-only replay gives
-    // the most debuggable signal per replay consumed.
-    replaysSessionSampleRate: 0,
+    // Error-only replay runs for everyone as a legitimate-interest
+    // debugging tool (covered by the existing privacy policy). Full
+    // session replay only activates for users who explicitly opted in
+    // via the Privacy and data toggles in criticalbit-auth-web's
+    // profile page. The 0.1 sample rate keeps us inside Sentry's free
+    // tier quota even under consented traffic bursts.
+    replaysSessionSampleRate: sessionReplayConsented ? 0.1 : 0,
     replaysOnErrorSampleRate: 1.0,
 
     enableLogs: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -21,6 +21,7 @@ import { SidebarNav } from "@/components/sidebar-nav"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { UserAvatar } from "@/components/user-avatar"
 import { useAuth } from "@/lib/auth"
+import type { ConsentsResponse } from "@/lib/consent"
 import { loginUrl, profileUrl } from "@/lib/config"
 
 const TanStackRouterDevtools = import.meta.env.PROD
@@ -48,6 +49,7 @@ interface RouterContext {
     userId: string | null
     displayName: string | null
     avatarUrl: string | null
+    consents: ConsentsResponse | null
     login: (email: string) => void
     logout: () => Promise<void>
     checkAuth: () => Promise<void>

--- a/src/test/renderers.tsx
+++ b/src/test/renderers.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from "@/components/theme-provider"
 import { AnalyticsProvider } from "@/lib/analytics"
 import { AuthProvider } from "@/lib/auth"
+import type { ConsentsResponse } from "@/lib/consent"
 import { FeatureFlagProvider } from "@/lib/feature-flags"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
@@ -23,6 +24,7 @@ interface RenderWithFileRoutesOptions extends Omit<RenderOptions, "wrapper"> {
       userId: string | null
       displayName: string | null
       avatarUrl: string | null
+      consents: ConsentsResponse | null
       login: (email: string) => void
       logout: () => Promise<void>
       checkAuth: () => Promise<void>
@@ -37,6 +39,7 @@ const defaultAuth = {
   userId: "test-user-id",
   displayName: "Test User",
   avatarUrl: null,
+  consents: null,
   login: () => {},
   logout: async () => {},
   checkAuth: async () => {},


### PR DESCRIPTION
## Summary
- **PostHog**: persistence switches from \`"memory"\` to \`"localStorage+cookie"\` only when the cached \`analytics\` consent is \`"1"\`. Otherwise PostHog stays in memory mode and \`posthog.reset(true)\` scrubs any leftover cookies from a prior consented session. \`track()\` and \`identify()\` are gated on a module-level \`capturingEnabled\` flag so nothing captures until opt-in is confirmed at init time.
- **Sentry session replay**: \`replaysSessionSampleRate\` flips between \`0\` (default) and \`0.1\` (consented). Error-only replay keeps running for everyone as a legitimate-interest debugging tool, covered by the existing privacy policy.
- **Auth context**: \`checkAuth()\` fetches \`/user/consents\` alongside \`/auth/me\`. On success it mirrors the latest state to \`localStorage\` (\`cb_consent_analytics\`, \`cb_consent_session_replay\`) so the next boot of this SPA picks up the fresh values synchronously.
- **Logout**: calls \`posthog.reset(true)\` before clearing auth state so cookies and distinct id are wiped — prevents a subsequent visitor on the same device from inheriting the previous identity.
- **CSP**: no change needed. \`connect-src\` already allows \`https://us.i.posthog.com\`.

Depends on criticalbit-auth-api#19 (shipped) for the consent endpoint.

## Design notes

**Why a localStorage cache for boot-time reads?** Both PostHog and Sentry initialize *synchronously* before React mounts (see \`main.tsx\`), but auth state resolves asynchronously via \`checkAuth()\`. Reading directly from auth context at init time isn't possible. Mid-session re-init of either library has historical issues (PostHog \`init\` on a dirty global, Sentry replay integration cannot be removed from \`integrations\` at runtime), so the safe pattern is: decide config at page load from a cached signal, update the cache after auth resolves, pick up the new value on the next page load.

**Consent-change lag.** A user who opts in/out via criticalbit-auth-web's profile page will not see the new state take effect in vagrant-story-web until their next page load of this site. This matches the "takes effect on next page reload" toast copy already shown in auth-web and is a deliberate trade-off against the risk of mid-session re-init breakage.

**Cross-origin localStorage.** localStorage is per-origin, so criticalbit-auth-web cannot write to vagrant-story-web's storage directly. Instead, each site calls \`/user/consents\` from its own origin (via \`credentials: include\` and the shared auth cookie on \`.criticalbit.gg\`) and caches the result locally. The backend is the source of truth; local caches are eventually-consistent mirrors.

## Test plan
- [x] \`pnpm build\` (\`tsc -b\` + vite build) — clean
- [x] \`pnpm lint\` — 43 pre-existing warnings, 0 errors; 2 \`react-refresh/only-export-components\` warnings on \`src/lib/analytics.tsx\` (one pre-existing for \`createAnalyticsBackend\`, one for the new \`resetAnalytics\` helper) match the existing file's pattern
- [x] \`pnpm format:check\` — clean
- [x] \`pnpm test:run\` — 16/16 pass
- [ ] Manual: log in as a user with \`analytics\` consent \`false\` → inspect DevTools, no PostHog cookie on \`.criticalbit.gg\`, no capture requests
- [ ] Manual: opt in via auth-web profile page → reload vagrant-story → PostHog cookie present, capture requests flowing, \`distinct_id\` persists across subdomain navigation
- [ ] Manual: opt out via auth-web → reload vagrant-story → cookies cleared (\`posthog.reset\` ran), capture requests stop
- [ ] Manual: logout from vagrant-story → PostHog cookies gone, next anonymous visit starts fresh