### PR TITLE
fix(inventory): persist tab state across tab switches

### DIFF
--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -190,6 +190,18 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
     },
     [navigate, activeTab, inventoryId]
   )
+  // Track which tabs have been visited so their state survives tab switches.
+  // Each tab stays mounted after first visit and is hidden via `hidden` while
+  // inactive — unmounting would discard search results, filter toggles, and
+  // analyze output the user cares about. Updating state during render (the
+  // React-supported "adjust state on prop change" pattern) converges in one
+  // extra pass and avoids the `setState-in-effect` and `refs-in-render` rules.
+  const [mountedTabs, setMountedTabs] = useState<Set<string>>(
+    () => new Set([activeTab])
+  )
+  if (!mountedTabs.has(activeTab)) {
+    setMountedTabs(new Set(mountedTabs).add(activeTab))
+  }
   const [editingSlot, setEditingSlot] = useState<SlotConfig | null>(null)
   const [editingBagItem, setEditingBagItem] = useState(false)
   const [bagSearch, setBagSearch] = useState("")
@@ -960,278 +972,214 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
         </Link>
       </div>
 
-      {/* Workbench Tab */}
-      {activeTab === "workbench" && (
-        <CraftingTab
-          items={allItems}
-          blades={blades}
-          armor={armor}
-          searchParams={search}
-          updateSearch={updateSearch}
-        />
+      {/* Workbench Tab — kept mounted after first visit so search results,
+          filter toggles, and expanded tree state survive tab switches. */}
+      {mountedTabs.has("workbench") && (
+        <div hidden={activeTab !== "workbench"}>
+          <CraftingTab
+            items={allItems}
+            blades={blades}
+            armor={armor}
+            searchParams={search}
+            updateSearch={updateSearch}
+          />
+        </div>
       )}
 
-      {/* Loadout Tab */}
-      {activeTab === "loadout" && (
-        <LoadoutTab
-          items={allItems}
-          inventoryId={inventoryId}
-          baseStats={
-            inventory.base_str != null
-              ? {
-                  hp: inventory.base_hp ?? 0,
-                  mp: inventory.base_mp ?? 0,
-                  str: inventory.base_str,
-                  int: inventory.base_int ?? 0,
-                  agi: inventory.base_agi ?? 0,
-                }
-              : undefined
-          }
-          searchParams={search}
-          updateSearch={updateSearch}
-        />
+      {/* Loadout Tab — kept mounted after first visit so analyze results and
+          inclusion toggles survive tab switches. */}
+      {mountedTabs.has("loadout") && (
+        <div hidden={activeTab !== "loadout"}>
+          <LoadoutTab
+            items={allItems}
+            inventoryId={inventoryId}
+            baseStats={
+              inventory.base_str != null
+                ? {
+                    hp: inventory.base_hp ?? 0,
+                    mp: inventory.base_mp ?? 0,
+                    str: inventory.base_str,
+                    int: inventory.base_int ?? 0,
+                    agi: inventory.base_agi ?? 0,
+                  }
+                : undefined
+            }
+            searchParams={search}
+            updateSearch={updateSearch}
+          />
+        </div>
       )}
 
       {/* Equipment Tab */}
-      {activeTab === "equipment" && (
-        <>
-          <DndContext
-            sensors={sensors}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-          >
-            {/* Shared filter controls for bag + container */}
-            <div className="flex items-center gap-2">
-              {itemCategories.length > 1 && (
-                <Select value={bagCategory} onValueChange={setBagCategory}>
-                  <SelectTrigger className="h-9 w-auto min-w-[7rem] shrink-0">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All ({allItems.length})</SelectItem>
-                    {itemCategories.map((c) => {
-                      const limitKey = ARMOR_POOL_TYPES.has(c.label)
-                        ? "Armor"
-                        : c.label
-                      const total =
-                        (BAG_LIMITS[limitKey] ?? 0) +
-                        (CONTAINER_LIMITS[limitKey] ?? 0)
-                      return (
-                        <SelectItem key={c.label} value={c.label}>
-                          {c.label} ({c.count}
-                          {total > 0 ? `/${total}` : ""})
-                        </SelectItem>
-                      )
-                    })}
-                  </SelectContent>
-                </Select>
+      <div hidden={activeTab !== "equipment"}>
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+        >
+          {/* Shared filter controls for bag + container */}
+          <div className="flex items-center gap-2">
+            {itemCategories.length > 1 && (
+              <Select value={bagCategory} onValueChange={setBagCategory}>
+                <SelectTrigger className="h-9 w-auto min-w-[7rem] shrink-0">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All ({allItems.length})</SelectItem>
+                  {itemCategories.map((c) => {
+                    const limitKey = ARMOR_POOL_TYPES.has(c.label)
+                      ? "Armor"
+                      : c.label
+                    const total =
+                      (BAG_LIMITS[limitKey] ?? 0) +
+                      (CONTAINER_LIMITS[limitKey] ?? 0)
+                    return (
+                      <SelectItem key={c.label} value={c.label}>
+                        {c.label} ({c.count}
+                        {total > 0 ? `/${total}` : ""})
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            )}
+            <div className="relative flex-1">
+              <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+              <Input
+                value={bagSearch}
+                onChange={(e) => setBagSearch(e.target.value)}
+                placeholder="Filter items..."
+                className="pr-8 pl-9"
+              />
+              {bagSearch && (
+                <button
+                  type="button"
+                  onClick={() => setBagSearch("")}
+                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+                >
+                  <X className="size-4" />
+                </button>
               )}
-              <div className="relative flex-1">
-                <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  value={bagSearch}
-                  onChange={(e) => setBagSearch(e.target.value)}
-                  placeholder="Filter items..."
-                  className="pr-8 pl-9"
-                />
-                {bagSearch && (
-                  <button
-                    type="button"
-                    onClick={() => setBagSearch("")}
-                    className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
-                  >
-                    <X className="size-4" />
-                  </button>
-                )}
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              onClick={() =>
+                setBagSort(
+                  bagSort === "equipped"
+                    ? "added"
+                    : bagSort === "added"
+                      ? "name"
+                      : "equipped"
+                )
+              }
+            >
+              {bagSort === "name" ? (
+                <ArrowDownAZ className="size-3.5" />
+              ) : (
+                <ArrowDownWideNarrow className="size-3.5" />
+              )}
+              {bagSort === "equipped"
+                ? "Equipped"
+                : bagSort === "added"
+                  ? "Added"
+                  : "Name"}
+            </Button>
+            <Button size="sm" onClick={() => setEditingBagItem(true)}>
+              <Plus className="size-3.5" />
+              Add Item
+            </Button>
+          </div>
+
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1.2fr)]">
+            {/* Left Column: Equipment + Stats */}
+            <div className="space-y-6 pt-2">
+              {/* Equipment Grid */}
+              <div className="mx-auto max-w-sm lg:max-w-none">
+                <h3 className="mb-3 text-base font-medium">
+                  <Swords className="mr-1.5 inline size-4" />
+                  Equipped
+                </h3>
+                <EquipmentGridDropZone
+                  isOver={
+                    activeDragItem !== null &&
+                    activeDragItem.equip_slot === null &&
+                    getEquipSlotForItem(activeDragItem) !== null
+                  }
+                >
+                  <EquipmentGrid
+                    getSlotItem={getSlotItem}
+                    getItemDisplayName={getItemDisplayName}
+                    getItemDisplayType={getItemDisplayType}
+                    getBladeInfo={getBladeInfo}
+                    onSlotClick={setEditingSlot}
+                    onUnequip={(slotItem) =>
+                      updateItemMutation.mutate({
+                        itemId: slotItem.id,
+                        equip_slot: null,
+                      })
+                    }
+                    equippedBladeIs2H={equippedBladeIs2H}
+                  />
+                </EquipmentGridDropZone>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="shrink-0"
-                onClick={() =>
-                  setBagSort(
-                    bagSort === "equipped"
-                      ? "added"
-                      : bagSort === "added"
-                        ? "name"
-                        : "equipped"
-                  )
-                }
-              >
-                {bagSort === "name" ? (
-                  <ArrowDownAZ className="size-3.5" />
-                ) : (
-                  <ArrowDownWideNarrow className="size-3.5" />
+
+              {/* Combined Stats */}
+              {combinedStats &&
+                inventory.items.some((i) => i.equip_slot != null) && (
+                  <CombinedStatsCard
+                    stats={combinedStats}
+                    baseStats={
+                      inventory.base_str != null
+                        ? {
+                            hp: inventory.base_hp ?? 0,
+                            mp: inventory.base_mp ?? 0,
+                            str: inventory.base_str,
+                            int: inventory.base_int ?? 0,
+                            agi: inventory.base_agi ?? 0,
+                          }
+                        : undefined
+                    }
+                  />
                 )}
-                {bagSort === "equipped"
-                  ? "Equipped"
-                  : bagSort === "added"
-                    ? "Added"
-                    : "Name"}
-              </Button>
-              <Button size="sm" onClick={() => setEditingBagItem(true)}>
-                <Plus className="size-3.5" />
-                Add Item
-              </Button>
             </div>
 
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1.2fr)]">
-              {/* Left Column: Equipment + Stats */}
-              <div className="space-y-6 pt-2">
-                {/* Equipment Grid */}
-                <div className="mx-auto max-w-sm lg:max-w-none">
-                  <h3 className="mb-3 text-base font-medium">
-                    <Swords className="mr-1.5 inline size-4" />
-                    Equipped
-                  </h3>
-                  <EquipmentGridDropZone
-                    isOver={
-                      activeDragItem !== null &&
-                      activeDragItem.equip_slot === null &&
-                      getEquipSlotForItem(activeDragItem) !== null
-                    }
-                  >
-                    <EquipmentGrid
-                      getSlotItem={getSlotItem}
-                      getItemDisplayName={getItemDisplayName}
-                      getItemDisplayType={getItemDisplayType}
-                      getBladeInfo={getBladeInfo}
-                      onSlotClick={setEditingSlot}
-                      onUnequip={(slotItem) =>
-                        updateItemMutation.mutate({
-                          itemId: slotItem.id,
-                          equip_slot: null,
-                        })
-                      }
-                      equippedBladeIs2H={equippedBladeIs2H}
-                    />
-                  </EquipmentGridDropZone>
-                </div>
-
-                {/* Combined Stats */}
-                {combinedStats &&
-                  inventory.items.some((i) => i.equip_slot != null) && (
-                    <CombinedStatsCard
-                      stats={combinedStats}
-                      baseStats={
-                        inventory.base_str != null
-                          ? {
-                              hp: inventory.base_hp ?? 0,
-                              mp: inventory.base_mp ?? 0,
-                              str: inventory.base_str,
-                              int: inventory.base_int ?? 0,
-                              agi: inventory.base_agi ?? 0,
-                            }
-                          : undefined
-                      }
-                    />
+            {/* Middle Column: Item Bag */}
+            <BagDropZone
+              isOver={
+                activeDragItem !== null &&
+                (activeDragItem.equip_slot !== null ||
+                  activeDragItem.storage === "container")
+              }
+            >
+              <div className="space-y-3">
+                <h3 className="text-base font-medium">
+                  <Package className="mr-1.5 inline size-4" />
+                  Item Bag ({filteredBagItems.length})
+                  {sectionLimits?.bag && (
+                    <span className="text-muted-foreground ml-2 text-sm font-normal">
+                      {sectionLimits.bag}
+                    </span>
                   )}
-              </div>
-
-              {/* Middle Column: Item Bag */}
-              <BagDropZone
-                isOver={
-                  activeDragItem !== null &&
-                  (activeDragItem.equip_slot !== null ||
-                    activeDragItem.storage === "container")
-                }
-              >
-                <div className="space-y-3">
-                  <h3 className="text-base font-medium">
-                    <Package className="mr-1.5 inline size-4" />
-                    Item Bag ({filteredBagItems.length})
-                    {sectionLimits?.bag && (
-                      <span className="text-muted-foreground ml-2 text-sm font-normal">
-                        {sectionLimits.bag}
-                      </span>
-                    )}
-                  </h3>
-                  {bagItems.length === 0 ? (
-                    <p className="text-muted-foreground py-4 text-center text-xs">
-                      No items in the bag
-                    </p>
-                  ) : filteredBagItems.length === 0 ? (
-                    <p className="text-muted-foreground py-4 text-center text-xs">
-                      No items match
-                      {bagCategory !== "all" && ` "${bagCategory}"`}
-                      {bagSearch && ` "${bagSearch}"`}
-                    </p>
-                  ) : (
-                    <div className="max-h-[60vh] space-y-1 overflow-y-auto">
-                      {filteredBagItems.map((item) => {
-                        const targetSlot = !item.equip_slot
-                          ? getEquipSlotForItem(item)
-                          : null
-                        return (
-                          <DraggableBagItemRow
-                            key={item.id}
-                            item={item}
-                            name={getItemDisplayName(item)}
-                            type={getItemDisplayType(item)}
-                            {...getBladeInfo(item)}
-                            isDraggable
-                            isDragging={activeDragItem?.id === item.id}
-                            onDelete={() => deleteItemMutation.mutate(item.id)}
-                            onUnequip={
-                              item.equip_slot
-                                ? () =>
-                                    updateItemMutation.mutate({
-                                      itemId: item.id,
-                                      equip_slot: null,
-                                    })
-                                : undefined
-                            }
-                            onEquip={
-                              targetSlot
-                                ? () => equipToSlot(item, targetSlot)
-                                : undefined
-                            }
-                            onMoveToContainer={
-                              !item.equip_slot
-                                ? () =>
-                                    updateItemMutation.mutate({
-                                      itemId: item.id,
-                                      storage: "container",
-                                    })
-                                : undefined
-                            }
-                          />
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              </BagDropZone>
-
-              {/* Right Column: Container */}
-              <ContainerDropZone
-                isOver={
-                  activeDragItem !== null &&
-                  activeDragItem.storage !== "container" &&
-                  !activeDragItem.equip_slot
-                }
-              >
-                <div className="space-y-3">
-                  <h3 className="text-base font-medium">
-                    <Package className="mr-1.5 inline size-4" />
-                    Container ({filteredContainerItems.length})
-                    {sectionLimits?.container && (
-                      <span className="text-muted-foreground ml-2 text-sm font-normal">
-                        {sectionLimits.container}
-                      </span>
-                    )}
-                  </h3>
-                  {containerItems.length === 0 ? (
-                    <p className="text-muted-foreground py-4 text-center text-xs">
-                      Drop items here to store them
-                    </p>
-                  ) : filteredContainerItems.length === 0 ? (
-                    <p className="text-muted-foreground py-4 text-center text-xs">
-                      No items match filter
-                    </p>
-                  ) : (
-                    <div className="max-h-[60vh] space-y-1 overflow-y-auto">
-                      {filteredContainerItems.map((item) => (
+                </h3>
+                {bagItems.length === 0 ? (
+                  <p className="text-muted-foreground py-4 text-center text-xs">
+                    No items in the bag
+                  </p>
+                ) : filteredBagItems.length === 0 ? (
+                  <p className="text-muted-foreground py-4 text-center text-xs">
+                    No items match
+                    {bagCategory !== "all" && ` "${bagCategory}"`}
+                    {bagSearch && ` "${bagSearch}"`}
+                  </p>
+                ) : (
+                  <div className="max-h-[60vh] space-y-1 overflow-y-auto">
+                    {filteredBagItems.map((item) => {
+                      const targetSlot = !item.equip_slot
+                        ? getEquipSlotForItem(item)
+                        : null
+                      return (
                         <DraggableBagItemRow
                           key={item.id}
                           item={item}
@@ -1241,103 +1189,171 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
                           isDraggable
                           isDragging={activeDragItem?.id === item.id}
                           onDelete={() => deleteItemMutation.mutate(item.id)}
-                          onMoveToBag={() =>
-                            updateItemMutation.mutate({
-                              itemId: item.id,
-                              storage: "bag",
-                            })
+                          onUnequip={
+                            item.equip_slot
+                              ? () =>
+                                  updateItemMutation.mutate({
+                                    itemId: item.id,
+                                    equip_slot: null,
+                                  })
+                              : undefined
+                          }
+                          onEquip={
+                            targetSlot
+                              ? () => equipToSlot(item, targetSlot)
+                              : undefined
+                          }
+                          onMoveToContainer={
+                            !item.equip_slot
+                              ? () =>
+                                  updateItemMutation.mutate({
+                                    itemId: item.id,
+                                    storage: "container",
+                                  })
+                              : undefined
                           }
                         />
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </ContainerDropZone>
-            </div>
-
-            <DragOverlay dropAnimation={null}>
-              {activeDragItem && (
-                <div className="bg-card border-primary/50 rounded-lg border px-3 py-2 shadow-lg">
-                  <div className="flex items-center gap-2">
-                    <ItemIcon
-                      type={getItemDisplayType(activeDragItem)}
-                      size="sm"
-                    />
-                    <span className="text-sm font-medium">
-                      {getItemDisplayName(activeDragItem)}
-                    </span>
-                  </div>
-                </div>
-              )}
-            </DragOverlay>
-          </DndContext>
-
-          {/* Slot Editor Dialog */}
-          {editingSlot && (
-            <SlotEditorDialog
-              slot={editingSlot}
-              existingItem={getSlotItem(editingSlot.key)}
-              blades={blades}
-              armor={armor}
-              grips={grips}
-              gems={gems}
-              consumables={consumables}
-              bladeMap={bladeMap}
-              bladeIdMap={bladeIdMap}
-              armorMap={armorMap}
-              armorIdMap={armorIdMap}
-              gripMap={gripMap}
-              gripIdMap={gripIdMap}
-              gemMap={gemMap}
-              gemIdMap={gemIdMap}
-              consumableMap={consumableMap}
-              consumableIdMap={consumableIdMap}
-              onSave={handleSlotSave}
-              onUnequip={
-                getSlotItem(editingSlot.key)
-                  ? () => {
-                      const item = getSlotItem(editingSlot.key)!
-                      updateItemMutation.mutate(
-                        { itemId: item.id, equip_slot: null },
-                        { onSuccess: () => setEditingSlot(null) }
                       )
-                    }
-                  : undefined
-              }
-              onClose={() => setEditingSlot(null)}
-              isPending={
-                addItemMutation.isPending || updateItemMutation.isPending
-              }
-            />
-          )}
+                    })}
+                  </div>
+                )}
+              </div>
+            </BagDropZone>
 
-          {/* Bag Item Editor Dialog */}
-          {editingBagItem && (
-            <SlotEditorDialog
-              slot={null}
-              existingItem={undefined}
-              blades={blades}
-              armor={armor}
-              grips={grips}
-              gems={gems}
-              consumables={consumables}
-              bladeMap={bladeMap}
-              bladeIdMap={bladeIdMap}
-              armorMap={armorMap}
-              armorIdMap={armorIdMap}
-              gripMap={gripMap}
-              gripIdMap={gripIdMap}
-              gemMap={gemMap}
-              gemIdMap={gemIdMap}
-              consumableMap={consumableMap}
-              consumableIdMap={consumableIdMap}
-              onSave={handleBagSave}
-              onClose={() => setEditingBagItem(false)}
-              isPending={addItemMutation.isPending}
-            />
-          )}
-        </>
-      )}
+            {/* Right Column: Container */}
+            <ContainerDropZone
+              isOver={
+                activeDragItem !== null &&
+                activeDragItem.storage !== "container" &&
+                !activeDragItem.equip_slot
+              }
+            >
+              <div className="space-y-3">
+                <h3 className="text-base font-medium">
+                  <Package className="mr-1.5 inline size-4" />
+                  Container ({filteredContainerItems.length})
+                  {sectionLimits?.container && (
+                    <span className="text-muted-foreground ml-2 text-sm font-normal">
+                      {sectionLimits.container}
+                    </span>
+                  )}
+                </h3>
+                {containerItems.length === 0 ? (
+                  <p className="text-muted-foreground py-4 text-center text-xs">
+                    Drop items here to store them
+                  </p>
+                ) : filteredContainerItems.length === 0 ? (
+                  <p className="text-muted-foreground py-4 text-center text-xs">
+                    No items match filter
+                  </p>
+                ) : (
+                  <div className="max-h-[60vh] space-y-1 overflow-y-auto">
+                    {filteredContainerItems.map((item) => (
+                      <DraggableBagItemRow
+                        key={item.id}
+                        item={item}
+                        name={getItemDisplayName(item)}
+                        type={getItemDisplayType(item)}
+                        {...getBladeInfo(item)}
+                        isDraggable
+                        isDragging={activeDragItem?.id === item.id}
+                        onDelete={() => deleteItemMutation.mutate(item.id)}
+                        onMoveToBag={() =>
+                          updateItemMutation.mutate({
+                            itemId: item.id,
+                            storage: "bag",
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </ContainerDropZone>
+          </div>
+
+          <DragOverlay dropAnimation={null}>
+            {activeDragItem && (
+              <div className="bg-card border-primary/50 rounded-lg border px-3 py-2 shadow-lg">
+                <div className="flex items-center gap-2">
+                  <ItemIcon
+                    type={getItemDisplayType(activeDragItem)}
+                    size="sm"
+                  />
+                  <span className="text-sm font-medium">
+                    {getItemDisplayName(activeDragItem)}
+                  </span>
+                </div>
+              </div>
+            )}
+          </DragOverlay>
+        </DndContext>
+
+        {/* Slot Editor Dialog */}
+        {editingSlot && (
+          <SlotEditorDialog
+            slot={editingSlot}
+            existingItem={getSlotItem(editingSlot.key)}
+            blades={blades}
+            armor={armor}
+            grips={grips}
+            gems={gems}
+            consumables={consumables}
+            bladeMap={bladeMap}
+            bladeIdMap={bladeIdMap}
+            armorMap={armorMap}
+            armorIdMap={armorIdMap}
+            gripMap={gripMap}
+            gripIdMap={gripIdMap}
+            gemMap={gemMap}
+            gemIdMap={gemIdMap}
+            consumableMap={consumableMap}
+            consumableIdMap={consumableIdMap}
+            onSave={handleSlotSave}
+            onUnequip={
+              getSlotItem(editingSlot.key)
+                ? () => {
+                    const item = getSlotItem(editingSlot.key)!
+                    updateItemMutation.mutate(
+                      { itemId: item.id, equip_slot: null },
+                      { onSuccess: () => setEditingSlot(null) }
+                    )
+                  }
+                : undefined
+            }
+            onClose={() => setEditingSlot(null)}
+            isPending={
+              addItemMutation.isPending || updateItemMutation.isPending
+            }
+          />
+        )}
+
+        {/* Bag Item Editor Dialog */}
+        {editingBagItem && (
+          <SlotEditorDialog
+            slot={null}
+            existingItem={undefined}
+            blades={blades}
+            armor={armor}
+            grips={grips}
+            gems={gems}
+            consumables={consumables}
+            bladeMap={bladeMap}
+            bladeIdMap={bladeIdMap}
+            armorMap={armorMap}
+            armorIdMap={armorIdMap}
+            gripMap={gripMap}
+            gripIdMap={gripIdMap}
+            gemMap={gemMap}
+            gemIdMap={gemIdMap}
+            consumableMap={consumableMap}
+            consumableIdMap={consumableIdMap}
+            onSave={handleBagSave}
+            onClose={() => setEditingBagItem(false)}
+            isPending={addItemMutation.isPending}
+          />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Inventory tabs were conditionally mounted with `{activeTab === X && <Tab />}`, so switching tabs unmounted the inactive component and discarded its internal state — workbench search results, decomposition trees, loadout analyze output, and include/exclude filter toggles all vanished on every switch.
- Switch to lazy-mount-and-keep-alive: each tab mounts on first visit and stays mounted behind the HTML `hidden` attribute while inactive. A `mountedTabs` `Set` (adjusted during render, React's supported pattern for deriving state from props) tracks which tabs have been opened so the workbench web worker init and loadout enemies fetch still only run when the user actually opens those tabs.
- Parent-owned state (`editingSlot`, `editingBagItem`, `bagSearch`) already survived switches, so this change only affects state owned by `CraftingTab` and `LoadoutTab`.

## Test plan
- [ ] Open an inventory, go to Workbench, run a forward search, note the results and any expanded tree rows
- [ ] Switch to Equipment, then back to Workbench — results and expanded state should still be there, table sort preserved
- [ ] Go to Loadout, pick an enemy, click Analyze, toggle off Equipped/Bag/Container
- [ ] Switch to Equipment and back to Loadout — analyze results and filter toggles should both persist
- [ ] First visit to Workbench/Loadout should still pay their init cost (worker spin-up, enemies query) exactly once — subsequent visits should be instant