### PR TITLE
chore(dev): switch local HTTPS from basic-ssl to mkcert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ dist-ssr
 # Playwright MCP session logs
 .playwright-mcp/
 
+# Local HTTPS dev certs (mkcert)
+.certs/
+
 # Local review artifacts (mobile/tablet screenshots, etc.)
 /mobile-*.png
 /tablet-*.png

--- a/README.md
+++ b/README.md
@@ -39,10 +39,24 @@ Pairs with [vagrant-story-api](../vagrant-story-api).
 
 ```bash
 pnpm install
-pnpm dev          # http://localhost:5173 (proxies /api to production API)
+pnpm dev          # https://localhost:5173 (proxies /api to production API)
 ```
 
 Set `VITE_API_URL=http://localhost:8000` in `.env` to point at a local backend instead of the production API.
+
+### Local auth (optional)
+
+Auth cookies are issued for `.criticalbit.gg` and marked `Secure`, so testing signed-in flows locally requires HTTPS on a `.criticalbit.gg` subdomain. One-time setup:
+
+1. Add `127.0.0.1 local.criticalbit.gg` to `/etc/hosts` (or the Windows equivalent).
+2. Install [mkcert](https://github.com/FiloSottile/mkcert) and trust the local CA: `mkcert -install`.
+3. Generate the dev cert into `.certs/` (gitignored):
+   ```bash
+   mkdir -p .certs
+   mkcert -key-file .certs/key.pem -cert-file .certs/cert.pem local.criticalbit.gg localhost 127.0.0.1 ::1
+   ```
+
+`pnpm dev` picks up the cert automatically when it exists and falls back to plain HTTP otherwise. Visit `https://local.criticalbit.gg:5173` (not `localhost`) so the browser can see the `.criticalbit.gg` auth cookies after sign-in.
 
 ### Common commands
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-basic-ssl": "^2.2.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.0",
     "@vitest/ui": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-basic-ssl':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -2303,12 +2300,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.57.0':
     resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vitejs/plugin-basic-ssl@2.2.0':
-    resolution: {integrity: sha512-nmyQ1HGRkfUxjsv3jw0+hMhEdZdrtkvMTdkzRUaRWfiO6PCWw2V2Pz3gldCq96Tn9S8htcgdTxw/gmbLLEbfYw==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    peerDependencies:
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -6258,10 +6249,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
-
-  '@vitejs/plugin-basic-ssl@2.2.0(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,18 @@
+import fs from "fs"
 import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
 import { sentryVitePlugin } from "@sentry/vite-plugin"
-import basicSsl from "@vitejs/plugin-basic-ssl"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+
+const certDir = path.resolve(__dirname, ".certs")
+const certFile = path.join(certDir, "cert.pem")
+const keyFile = path.join(certDir, "key.pem")
+const httpsConfig =
+  fs.existsSync(certFile) && fs.existsSync(keyFile)
+    ? { cert: fs.readFileSync(certFile), key: fs.readFileSync(keyFile) }
+    : undefined
 
 const API_TARGET =
   process.env.NODE_ENV === "development"
@@ -34,7 +42,6 @@ export default defineConfig({
     }),
     react(),
     tailwindcss(),
-    basicSsl(),
     sentryAuthToken && sentryOrg && sentryProject
       ? sentryVitePlugin({
           authToken: sentryAuthToken,
@@ -50,6 +57,7 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    https: httpsConfig,
     allowedHosts: ["local.criticalbit.gg"],
     proxy: {
       "/api": {


### PR DESCRIPTION
## Summary

- `vite.config.ts` now reads `.certs/cert.pem` / `.certs/key.pem` for the dev server's HTTPS config, replacing `@vitejs/plugin-basic-ssl`.
- `.certs/` added to `.gitignore`.
- `@vitejs/plugin-basic-ssl` removed from `devDependencies`.
- README gets a new **Local auth (optional)** subsection documenting the one-time mkcert setup.

## Why

Auth cookies for `.criticalbit.gg` are `Secure`, so testing signed-in flows locally requires HTTPS on a `.criticalbit.gg` subdomain (the setup that already exists: `/etc/hosts` → `local.criticalbit.gg`, Vite `allowedHosts`). The cert piece was handled by `@vitejs/plugin-basic-ssl`, which issues a self-signed cert that Chrome rejects with "This site can't provide a secure connection" — sometimes with no bypass at all depending on Chrome's HSTS state. That made local auth testing impossible without workarounds like typing `thisisunsafe` on the warning page.

mkcert issues a cert signed by a locally-trusted root CA, so Chrome (and Firefox, and curl) treat it as a real cert. No warning page, no HSTS interaction, no manual bypass.

## Soft-fallback behavior

The config intentionally degrades gracefully: if `.certs/cert.pem` or `.certs/key.pem` is missing (e.g. a teammate hasn't run `mkcert` yet), `pnpm dev` still starts — just over plain HTTP. They won't be able to test auth flows, but everything else works. This avoids a hard failure for contributors who only touch public pages.

## Test plan

- [x] Generated `.certs/` via mkcert locally
- [x] `pnpm dev` serves over HTTPS on 5173 with a clean cert (no warning)
- [x] `https://local.criticalbit.gg:5173` loads without Chrome complaints
- [x] Sign-in → redirect to prod auth → redirect back → session established end-to-end
- [x] Pre-commit pipeline passes (lint + test + build)