### PR TITLE
feat(home): clickable Workbench/Loadout sub-features in Tools section

### DIFF
--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -1,9 +1,9 @@
-import { useQuery } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
-import { ArrowRight } from "lucide-react"
 import { ItemIcon } from "@/components/item-icon"
 import { Card, CardContent } from "@/components/ui/card"
 import { gameApi } from "@/lib/game-api"
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { ArrowRight } from "lucide-react"
 
 export function HomePage() {
   const { data: blades = [] } = useQuery({
@@ -218,39 +218,25 @@ export function HomePage() {
           <h2 className="mb-6 text-2xl tracking-wide">Tools</h2>
           <div className="flex flex-col gap-6">
             {/* Inventory — hero card */}
-            <Link to="/inventory">
-              <Card className="border-primary/30 hover:border-primary/50 transition-colors">
-                <CardContent className="flex flex-col gap-4 pt-6">
-                  <div className="flex items-start gap-3">
-                    <ItemIcon type="Inventory" size="sm" />
-                    <div>
-                      <h3 className="font-sans text-lg font-medium">
-                        Inventory
-                      </h3>
-                      <p className="text-muted-foreground mt-1 text-sm">
-                        Import your save file to unlock powerful crafting and
-                        loadout tools for your equipment.
-                      </p>
-                    </div>
+            <Card className="border-primary/30 hover:border-primary/50 transition-colors">
+              <CardContent className="flex flex-col gap-4 pt-6">
+                <Link to="/inventory" className="flex items-start gap-3">
+                  <ItemIcon type="Inventory" size="sm" />
+                  <div>
+                    <h3 className="font-sans text-lg font-medium">Inventory</h3>
+                    <p className="text-muted-foreground mt-1 text-sm">
+                      Import your save file to unlock powerful crafting and
+                      loadout tools for your equipment.
+                    </p>
                   </div>
-                  <div className="grid gap-3 sm:grid-cols-3">
-                    <div className="bg-muted/30 flex items-start gap-3 rounded-lg p-3">
-                      <div className="bg-primary text-primary-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
-                        <img
-                          src="/images/icons/Swords.svg"
-                          alt="Equipment"
-                          className="size-5"
-                        />
-                      </div>
-                      <div>
-                        <p className="text-sm font-medium">Equipment</p>
-                        <p className="text-muted-foreground text-xs">
-                          Manage gear and see combined stats across all equipped
-                          pieces.
-                        </p>
-                      </div>
-                    </div>
-                    <div className="bg-muted/30 flex items-start gap-3 rounded-lg p-3">
+                </Link>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Link
+                    to="/inventory"
+                    search={{ tab: "workbench" }}
+                    className="border-border hover:border-primary/40 hover:bg-muted/50 flex flex-col gap-3 rounded-lg border p-4 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
                       <div className="bg-primary text-primary-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
                         <img
                           src="/images/icons/HammerPick.svg"
@@ -258,15 +244,20 @@ export function HomePage() {
                           className="size-5"
                         />
                       </div>
-                      <div>
-                        <p className="text-sm font-medium">Workbench</p>
-                        <p className="text-muted-foreground text-xs">
-                          Find optimal crafting paths for your inventory items
-                          and discover upgrades.
-                        </p>
-                      </div>
+                      <p className="text-sm font-medium">Workbench</p>
                     </div>
-                    <div className="bg-muted/30 flex items-start gap-3 rounded-lg p-3">
+                    <ul className="text-muted-foreground space-y-1 text-xs">
+                      <li>• Discover every item you can craft right now</li>
+                      <li>• Multi-step paths to reach any target item</li>
+                      <li>• Filter by workshop and material tier</li>
+                    </ul>
+                  </Link>
+                  <Link
+                    to="/inventory"
+                    search={{ tab: "loadout" }}
+                    className="border-border hover:border-primary/40 hover:bg-muted/50 flex flex-col gap-3 rounded-lg border p-4 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
                       <div className="bg-primary text-primary-foreground flex size-8 shrink-0 items-center justify-center rounded-lg">
                         <img
                           src="/images/icons/Loadout.svg"
@@ -274,18 +265,22 @@ export function HomePage() {
                           className="size-5"
                         />
                       </div>
-                      <div>
-                        <p className="text-sm font-medium">Loadout</p>
-                        <p className="text-muted-foreground text-xs">
-                          Build and compare equipment loadouts to optimize your
-                          setup.
-                        </p>
-                      </div>
+                      <p className="text-sm font-medium">Loadout</p>
                     </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+                    <ul className="text-muted-foreground space-y-1 text-xs">
+                      <li>• Get optimal equipment picks for any enemy</li>
+                      <li>
+                        • Offense, defense, or balanced optimization modes
+                      </li>
+                      <li>
+                        • Scored using the actual VS damage formula, including
+                        elements and affinities
+                      </li>
+                    </ul>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
 
             {/* Other tools */}
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -163,6 +163,31 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
         })
       ? "workbench"
       : "equipment"
+
+  // When arriving with ?tab=workbench or ?tab=loadout (e.g. from home page),
+  // the path-based activeTab defaults to "equipment". Redirect to the
+  // requested sub-route and strip the tab param so it's a one-time action.
+  const requestedTab = search.tab
+  if (
+    requestedTab &&
+    requestedTab !== activeTab &&
+    (requestedTab === "workbench" || requestedTab === "loadout")
+  ) {
+    const tabRoute =
+      requestedTab === "workbench"
+        ? "/inventory/$inventoryId/workbench"
+        : "/inventory/$inventoryId/loadout"
+    navigate({
+      to: tabRoute,
+      params: { inventoryId: String(inventoryId) },
+      search: (prev) => {
+        const next = { ...prev }
+        delete (next as Record<string, unknown>).tab
+        return next
+      },
+      replace: true,
+    })
+  }
   // Route search-param updates back to the active subroute explicitly.
   // A route-bound navigate on the parent would resolve to /inventory/$inventoryId,
   // whose index redirects to /equipment — silently kicking users off workbench/loadout.

--- a/src/pages/inventory/inventory-detail.tsx
+++ b/src/pages/inventory/inventory-detail.tsx
@@ -164,30 +164,6 @@ function InventoryDetail({ inventoryId }: { inventoryId: number }) {
       ? "workbench"
       : "equipment"
 
-  // When arriving with ?tab=workbench or ?tab=loadout (e.g. from home page),
-  // the path-based activeTab defaults to "equipment". Redirect to the
-  // requested sub-route and strip the tab param so it's a one-time action.
-  const requestedTab = search.tab
-  if (
-    requestedTab &&
-    requestedTab !== activeTab &&
-    (requestedTab === "workbench" || requestedTab === "loadout")
-  ) {
-    const tabRoute =
-      requestedTab === "workbench"
-        ? "/inventory/$inventoryId/workbench"
-        : "/inventory/$inventoryId/loadout"
-    navigate({
-      to: tabRoute,
-      params: { inventoryId: String(inventoryId) },
-      search: (prev) => {
-        const next = { ...prev }
-        delete (next as Record<string, unknown>).tab
-        return next
-      },
-      replace: true,
-    })
-  }
   // Route search-param updates back to the active subroute explicitly.
   // A route-bound navigate on the parent would resolve to /inventory/$inventoryId,
   // whose index redirects to /equipment — silently kicking users off workbench/loadout.

--- a/src/pages/inventory/inventory-list.tsx
+++ b/src/pages/inventory/inventory-list.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
+import { getRouteApi, Link } from "@tanstack/react-router"
 import {
   ArrowDownAZ,
   ArrowDownWideNarrow,
@@ -73,9 +73,12 @@ function InventoryListSkeleton() {
   )
 }
 
+const inventoryListRouteApi = getRouteApi("/inventory/")
+
 function InventoryList() {
   const queryClient = useQueryClient()
   const analytics = useAnalytics()
+  const { tab } = inventoryListRouteApi.useSearch()
   const [showCreate, setShowCreate] = useState(false)
   const [newName, setNewName] = useState("")
   const [deleteTarget, setDeleteTarget] = useState<InventoryListItem | null>(
@@ -224,6 +227,7 @@ function InventoryList() {
           <InventoryCard
             key={inv.id}
             inventory={inv}
+            tab={tab}
             onDelete={() => setDeleteTarget(inv)}
           />
         ))}
@@ -299,15 +303,18 @@ function InventoryList() {
 
 function InventoryCard({
   inventory,
+  tab,
   onDelete,
 }: {
   inventory: InventoryListItem
+  tab?: "equipment" | "workbench" | "loadout"
   onDelete: () => void
 }) {
   return (
     <Link
       to="/inventory/$inventoryId"
       params={{ inventoryId: String(inventory.id) }}
+      search={tab ? { tab } : {}}
     >
       <Card className="hover:border-foreground/20 cursor-pointer transition-colors">
         <CardContent className="flex items-center justify-between">

--- a/src/routes/inventory/$inventoryId/index.tsx
+++ b/src/routes/inventory/$inventoryId/index.tsx
@@ -1,32 +1,23 @@
-import { createFileRoute, Navigate, getRouteApi } from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/inventory/$inventoryId/")({
-  component: RedirectToTab,
-})
-
-const parentRoute = getRouteApi("/inventory/$inventoryId")
-
-function RedirectToTab() {
-  const { inventoryId } = Route.useParams()
-  const { tab } = parentRoute.useSearch()
-
-  const target =
-    tab === "workbench"
-      ? "/inventory/$inventoryId/workbench"
-      : tab === "loadout"
-        ? "/inventory/$inventoryId/loadout"
-        : "/inventory/$inventoryId/equipment"
-
-  return (
-    <Navigate
-      to={target}
-      params={{ inventoryId }}
-      search={(prev) => {
+  beforeLoad: ({ params, search }) => {
+    const { tab } = search as { tab?: "equipment" | "workbench" | "loadout" }
+    const to =
+      tab === "workbench"
+        ? "/inventory/$inventoryId/workbench"
+        : tab === "loadout"
+          ? "/inventory/$inventoryId/loadout"
+          : "/inventory/$inventoryId/equipment"
+    throw redirect({
+      to,
+      params,
+      search: (prev) => {
         const next = { ...prev }
         delete (next as Record<string, unknown>).tab
         return next
-      }}
-      replace
-    />
-  )
-}
+      },
+      replace: true,
+    })
+  },
+})

--- a/src/routes/inventory/$inventoryId/index.tsx
+++ b/src/routes/inventory/$inventoryId/index.tsx
@@ -1,16 +1,21 @@
-import { createFileRoute, Navigate } from "@tanstack/react-router"
+import { createFileRoute, Navigate, getRouteApi } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/inventory/$inventoryId/")({
-  component: RedirectToEquipment,
+  component: RedirectToTab,
 })
 
-function RedirectToEquipment() {
+const parentRoute = getRouteApi("/inventory/$inventoryId")
+
+function RedirectToTab() {
   const { inventoryId } = Route.useParams()
-  return (
-    <Navigate
-      to="/inventory/$inventoryId/equipment"
-      params={{ inventoryId }}
-      replace
-    />
-  )
+  const { tab } = parentRoute.useSearch()
+
+  const target =
+    tab === "workbench"
+      ? "/inventory/$inventoryId/workbench"
+      : tab === "loadout"
+        ? "/inventory/$inventoryId/loadout"
+        : "/inventory/$inventoryId/equipment"
+
+  return <Navigate to={target} params={{ inventoryId }} replace />
 }

--- a/src/routes/inventory/$inventoryId/index.tsx
+++ b/src/routes/inventory/$inventoryId/index.tsx
@@ -17,5 +17,16 @@ function RedirectToTab() {
         ? "/inventory/$inventoryId/loadout"
         : "/inventory/$inventoryId/equipment"
 
-  return <Navigate to={target} params={{ inventoryId }} replace />
+  return (
+    <Navigate
+      to={target}
+      params={{ inventoryId }}
+      search={(prev) => {
+        const next = { ...prev }
+        delete (next as Record<string, unknown>).tab
+        return next
+      }}
+      replace
+    />
+  )
 }

--- a/src/routes/inventory/$inventoryId/route.tsx
+++ b/src/routes/inventory/$inventoryId/route.tsx
@@ -2,6 +2,8 @@ import { createFileRoute } from "@tanstack/react-router"
 import { InventoryDetailPage } from "@/pages/inventory/inventory-detail"
 
 export type InventorySearch = {
+  // Tab selection
+  tab?: "equipment" | "workbench" | "loadout"
   // Equipment tab
   sort?: string
   cat?: string
@@ -15,9 +17,15 @@ export type InventorySearch = {
   lmode?: string
 }
 
+const VALID_TABS = new Set(["equipment", "workbench", "loadout"])
+
 export const Route = createFileRoute("/inventory/$inventoryId")({
   component: InventoryDetailPage,
   validateSearch: (search: Record<string, unknown>): InventorySearch => ({
+    tab:
+      typeof search.tab === "string" && VALID_TABS.has(search.tab)
+        ? (search.tab as InventorySearch["tab"])
+        : undefined,
     sort: typeof search.sort === "string" ? search.sort : undefined,
     cat: typeof search.cat === "string" ? search.cat : undefined,
     wcat: typeof search.wcat === "string" ? search.wcat : undefined,

--- a/src/routes/inventory/index.tsx
+++ b/src/routes/inventory/index.tsx
@@ -1,6 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { InventoryListPage } from "@/pages/inventory/inventory-list"
 
+export type InventoryListSearch = {
+  tab?: "equipment" | "workbench" | "loadout"
+}
+
+const VALID_TABS = new Set(["equipment", "workbench", "loadout"])
+
 export const Route = createFileRoute("/inventory/")({
   component: InventoryListPage,
+  validateSearch: (search: Record<string, unknown>): InventoryListSearch => ({
+    tab:
+      typeof search.tab === "string" && VALID_TABS.has(search.tab)
+        ? (search.tab as InventoryListSearch["tab"])
+        : undefined,
+  }),
 })


### PR DESCRIPTION
## Summary

- Split the homepage Inventory card into three clickable surfaces: the top hero link opens the inventory list, and new sub-cards deep-link straight into the **Workbench** and **Loadout** tabs.
- Richer sub-feature copy (bullet lists) replaces the old two-liners so the value prop for each tool is visible at a glance from the home page.
- URL-driven deep linking: `/inventory?tab=workbench|loadout` is validated by the list route, passed through the inventory card link, and stripped cleanly by the detail route's index redirect so users land on a clean `/inventory/:id/workbench` URL.

## Implementation notes

- Added `tab` to the search schemas of both `/inventory/` (list) and `/inventory/\$inventoryId` (detail) with a `VALID_TABS` allowlist so bogus values are dropped at the route boundary.
- `$inventoryId/index.tsx`'s `<Navigate>` uses a `search` transform to strip `tab` on redirect, so the final URL is `/workbench` or `/loadout` without a dangling query param. The redirect stays declarative at the route that owns it, rather than hiding it inside the detail-page component.

## Test plan

- [x] Home page renders new Tools section with two sub-cards
- [x] Lint / tests / build all green locally
- [ ] Click Workbench card on home → lands on `/inventory/:id/workbench` with no `?tab=` query param
- [ ] Click Loadout card on home → lands on `/inventory/:id/loadout` with no `?tab=` query param
- [ ] Clicking top "Inventory" hero still opens the list page
- [ ] Invalid `?tab=` value in URL falls through to default (equipment)