### PR TITLE
feat(seo): add OG tags, robots.txt, and build-time sitemap generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dist-ssr
 
 # TypeScript
 *.tsbuildinfo
+
+# Generated at build time by scripts/generate-sitemap.mjs
+/public/sitemap.xml

--- a/index.html
+++ b/index.html
@@ -9,6 +9,49 @@
       content="default-src 'self'; script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.criticalbit.gg https://us.i.posthog.com https://us-assets.i.posthog.com https://*.ingest.us.sentry.io; img-src 'self' data: https:; object-src 'none'; frame-src 'none'; form-action 'self'; upgrade-insecure-requests; base-uri 'self'"
     />
     <title>Vagrant Story — criticalbit.gg</title>
+    <meta
+      name="description"
+      content="Community game database and crafting tools for Vagrant Story (PS1). Browse weapons, armor, gems, spells, enemies, crafting recipes, and plan your build with the Forge and Inventory planners."
+    />
+    <link rel="canonical" href="https://vagrant-story.criticalbit.gg/" />
+    <meta name="theme-color" content="#0b1220" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="criticalbit.gg" />
+    <meta property="og:title" content="Vagrant Story — criticalbit.gg" />
+    <meta
+      property="og:description"
+      content="Community game database and crafting tools for Vagrant Story (PS1). Browse weapons, armor, gems, spells, enemies, crafting recipes, and plan your build."
+    />
+    <meta property="og:url" content="https://vagrant-story.criticalbit.gg/" />
+    <meta
+      property="og:image"
+      content="https://vagrant-story.criticalbit.gg/og-image.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Vagrant Story database and crafting tools on criticalbit.gg"
+    />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vagrant Story — criticalbit.gg" />
+    <meta
+      name="twitter:description"
+      content="Community game database and crafting tools for Vagrant Story (PS1)."
+    />
+    <meta
+      name="twitter:image"
+      content="https://vagrant-story.criticalbit.gg/og-image.png"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Vagrant Story database and crafting tools on criticalbit.gg"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "vitest": "^4.1.0"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,json,css,md}": "prettier --write"
+    "*.{ts,tsx,js,jsx,mjs,cjs,json,css,md}": "prettier --write"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run generate-routes && tsc -b && vite build",
+    "build": "pnpm run generate-routes && pnpm run generate-sitemap && tsc -b && vite build",
     "generate-api": "orval",
+    "generate-sitemap": "node scripts/generate-sitemap.mjs",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vagrant-story.criticalbit.gg/sitemap.xml

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -139,8 +139,7 @@ function renderSitemap(entries) {
     if (entry.lastmod) lines.push(`    <lastmod>${entry.lastmod}</lastmod>`)
     if (entry.changefreq)
       lines.push(`    <changefreq>${entry.changefreq}</changefreq>`)
-    if (entry.priority)
-      lines.push(`    <priority>${entry.priority}</priority>`)
+    if (entry.priority) lines.push(`    <priority>${entry.priority}</priority>`)
     lines.push("  </url>")
   }
   lines.push("</urlset>")

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// Generates public/sitemap.xml at build time by fetching all detail-page
+// entities from the production API and combining them with the static
+// route list. Run by `pnpm build` before vite bundles the app.
+
+import { writeFile, mkdir } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const SITE_URL = (
+  process.env.SITE_URL || "https://vagrant-story.criticalbit.gg"
+).replace(/\/+$/, "")
+
+const API_URL = (
+  process.env.SITEMAP_API_URL || "https://vagrant-story-api.criticalbit.gg"
+).replace(/\/+$/, "")
+
+const __filename = fileURLToPath(import.meta.url)
+const OUT_PATH = resolve(__filename, "../../public/sitemap.xml")
+
+const STATIC_ROUTES = [
+  { path: "/", priority: "1.0", changefreq: "weekly" },
+  // Tools
+  { path: "/inventory", priority: "0.9", changefreq: "monthly" },
+  { path: "/forge", priority: "0.9", changefreq: "monthly" },
+  { path: "/crafting", priority: "0.9", changefreq: "monthly" },
+  { path: "/material-grid", priority: "0.8", changefreq: "monthly" },
+  { path: "/materials", priority: "0.8", changefreq: "monthly" },
+  // Equipment lists
+  { path: "/blades", priority: "0.8", changefreq: "monthly" },
+  { path: "/grips", priority: "0.8", changefreq: "monthly" },
+  { path: "/armor", priority: "0.8", changefreq: "monthly" },
+  { path: "/accessories", priority: "0.8", changefreq: "monthly" },
+  { path: "/gems", priority: "0.8", changefreq: "monthly" },
+  { path: "/consumables", priority: "0.8", changefreq: "monthly" },
+  // Combat lists
+  { path: "/break-arts", priority: "0.8", changefreq: "monthly" },
+  { path: "/battle-abilities", priority: "0.8", changefreq: "monthly" },
+  { path: "/spells", priority: "0.8", changefreq: "monthly" },
+  { path: "/grimoires", priority: "0.8", changefreq: "monthly" },
+  // World lists
+  { path: "/bestiary", priority: "0.8", changefreq: "monthly" },
+  { path: "/areas", priority: "0.8", changefreq: "monthly" },
+  { path: "/workshops", priority: "0.8", changefreq: "monthly" },
+  { path: "/chests", priority: "0.8", changefreq: "monthly" },
+  { path: "/characters", priority: "0.8", changefreq: "monthly" },
+  // Progression lists
+  { path: "/keys", priority: "0.8", changefreq: "monthly" },
+  { path: "/sigils", priority: "0.8", changefreq: "monthly" },
+  { path: "/titles", priority: "0.8", changefreq: "monthly" },
+  { path: "/rankings", priority: "0.8", changefreq: "monthly" },
+]
+
+async function fetchList(path) {
+  const url = `${API_URL}${path}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`GET ${url} → ${res.status} ${res.statusText}`)
+  }
+  const data = await res.json()
+  if (!Array.isArray(data)) {
+    throw new Error(`GET ${url} → expected array, got ${typeof data}`)
+  }
+  return data
+}
+
+// Limits match src/lib/game-api.ts exactly — those values are validated
+// against whatever per-endpoint cap the API enforces, so matching them
+// guarantees the sitemap covers every entity the app itself can surface.
+const ENTITY_ENDPOINTS = [
+  { prefix: "/blades", api: "/blades?limit=200" },
+  { prefix: "/grips", api: "/grips?limit=200" },
+  { prefix: "/gems", api: "/gems?limit=200" },
+  { prefix: "/consumables", api: "/consumables?limit=200" },
+  { prefix: "/break-arts", api: "/break-arts?limit=200" },
+  { prefix: "/battle-abilities", api: "/battle-abilities?limit=200" },
+  { prefix: "/spells", api: "/spells?limit=200" },
+  { prefix: "/grimoires", api: "/grimoires?limit=500" },
+  { prefix: "/bestiary", api: "/enemies?limit=200" },
+  { prefix: "/areas", api: "/areas?limit=200" },
+  { prefix: "/workshops", api: "/workshops?limit=200" },
+  { prefix: "/chests", api: "/chests?limit=500" },
+  { prefix: "/characters", api: "/characters?limit=200" },
+  { prefix: "/keys", api: "/keys?limit=200" },
+  { prefix: "/sigils", api: "/sigils?limit=200" },
+  { prefix: "/titles", api: "/titles?limit=200" },
+  { prefix: "/rankings", api: "/rankings?limit=200" },
+]
+
+async function collectDetailUrls() {
+  const urls = []
+
+  const results = await Promise.all([
+    ...ENTITY_ENDPOINTS.map(async ({ prefix, api }) => {
+      const rows = await fetchList(api)
+      return rows.map((row) => `${prefix}/${row.id}`)
+    }),
+    // Armor and accessories share the same underlying /armor endpoint.
+    // Split by armor_type so the sitemap emits each item exactly once
+    // under its canonical route.
+    (async () => {
+      const rows = await fetchList("/armor?limit=200")
+      const armorPaths = []
+      for (const row of rows) {
+        if (row.armor_type === "Accessory") {
+          armorPaths.push(`/accessories/${row.id}`)
+        } else {
+          armorPaths.push(`/armor/${row.id}`)
+        }
+      }
+      return armorPaths
+    })(),
+  ])
+
+  for (const batch of results) {
+    urls.push(...batch)
+  }
+
+  return urls
+}
+
+function xmlEscape(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}
+
+function renderSitemap(entries) {
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  ]
+  for (const entry of entries) {
+    lines.push("  <url>")
+    lines.push(`    <loc>${xmlEscape(entry.loc)}</loc>`)
+    if (entry.lastmod) lines.push(`    <lastmod>${entry.lastmod}</lastmod>`)
+    if (entry.changefreq)
+      lines.push(`    <changefreq>${entry.changefreq}</changefreq>`)
+    if (entry.priority)
+      lines.push(`    <priority>${entry.priority}</priority>`)
+    lines.push("  </url>")
+  }
+  lines.push("</urlset>")
+  lines.push("")
+  return lines.join("\n")
+}
+
+async function main() {
+  const today = new Date().toISOString().slice(0, 10)
+
+  const entries = STATIC_ROUTES.map((route) => ({
+    loc: `${SITE_URL}${route.path}`,
+    lastmod: today,
+    changefreq: route.changefreq,
+    priority: route.priority,
+  }))
+
+  console.log(`[sitemap] Fetching detail URLs from ${API_URL}`)
+  const detailPaths = await collectDetailUrls()
+  console.log(`[sitemap] Collected ${detailPaths.length} detail URLs`)
+
+  for (const path of detailPaths) {
+    entries.push({
+      loc: `${SITE_URL}${path}`,
+      lastmod: today,
+      changefreq: "monthly",
+      priority: "0.6",
+    })
+  }
+
+  const xml = renderSitemap(entries)
+  await mkdir(dirname(OUT_PATH), { recursive: true })
+  await writeFile(OUT_PATH, xml, "utf8")
+  console.log(
+    `[sitemap] Wrote ${entries.length} URLs → ${OUT_PATH.replace(process.cwd() + "/", "")}`
+  )
+}
+
+main().catch((err) => {
+  console.error("[sitemap] Generation failed:", err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Launch-ready social unfurl and search engine discovery bundle. Three moving pieces:

- **Meta tags** in `index.html`: Open Graph, Twitter Card (`summary_large_image`), description, canonical, and theme-color. Baked statically into the HTML so non-JS social crawlers (Discord, Slack, Facebook, Twitter) see them on first fetch — React/runtime head manipulation would not work for unfurl.
- **`public/robots.txt`**: allow-all + sitemap pointer.
- **`scripts/generate-sitemap.mjs`**: zero-dep Node ESM script that hits the production API at build time and writes `public/sitemap.xml`. Runs between `generate-routes` and `tsc` in the build chain. First run output: **830 URLs** (25 static routes + 805 detail pages). The generated file is gitignored.

### Accessory/armor split in the sitemap

Accessories are not a separate API entity in this codebase — they're `Armor` rows filtered by `armor_type === "Accessory"`. The sitemap generator mirrors that split so `/armor/$id` and `/accessories/$id` point at disjoint item sets, avoiding duplicate-content URLs competing for the same underlying row.

### Fail-fast on API errors

The script exits non-zero if the API is unreachable or returns unexpected data, rather than silently emitting a partial sitemap. Better to catch a broken build than ship a sitemap missing 80% of pages that nobody notices.

## Out of scope (tracked separately)

- [#146](https://github.com/ag-tech-group/vagrant-story-web/issues/146) — create `public/og-image.png` (1200×630). The meta tags already reference this path; the asset is intentionally not committed to avoid placeholder rot.
- [#147](https://github.com/ag-tech-group/vagrant-story-web/issues/147) — submit the sitemap to Google Search Console and Bing Webmaster Tools post-launch.

## Test plan

- [x] `pnpm run generate-sitemap` → 830 URLs written
- [x] `pnpm run lint` → 0 errors (42 pre-existing warnings untouched)
- [x] `pnpm run build` → passes; sitemap regenerates during build
- [x] `pnpm run test:run` → 16/16 passing
- [x] `dist/index.html` contains all OG/Twitter meta tags after build
- [x] `dist/robots.txt` and `dist/sitemap.xml` present after build
- [x] Local dev server: `/robots.txt` and `/sitemap.xml` both serve correctly
- [x] View-source on a page shows the expected `og:*` / `twitter:*` / `name="description"` / `rel="canonical"` tags
- [ ] Post-deploy: verify unfurl renders via Facebook Sharing Debugger and a Discord paste test (requires the og-image.png from #146)