### PR TITLE
feat(api): migrate frontend to /v1 API paths

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -52,7 +52,7 @@ const STATIC_ROUTES = [
 ]
 
 async function fetchList(path) {
-  const url = `${API_URL}${path}`
+  const url = `${API_URL}/v1${path}`
   const res = await fetch(url)
   if (!res.ok) {
     throw new Error(`GET ${url} → ${res.status} ${res.statusText}`)

--- a/src/lib/game-api.ts
+++ b/src/lib/game-api.ts
@@ -402,7 +402,7 @@ export interface ItemDropLocation {
 }
 
 async function fetchApi<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_URL}${path}`)
+  const res = await fetch(`${API_URL}/v1${path}`)
   if (!res.ok) throw new Error(`API error: ${res.status}`)
   return res.json()
 }


### PR DESCRIPTION
## Summary

Two one-line changes to route both the runtime client and the build-time sitemap generator at the new \`/v1\` API:

- \`src/lib/game-api.ts\` — \`fetchApi\` now fetches \`\${API_URL}/v1\${path}\`
- \`scripts/generate-sitemap.mjs\` — \`fetchList\` likewise

## Dependency already satisfied

This depends on [ag-tech-group/vagrant-story-api#73](https://github.com/ag-tech-group/vagrant-story-api/pull/73) being **deployed**, not just merged — because the sitemap generator hits the production API at build time. Verified locally before opening this PR:

\`\`\`
$ curl -s -o /dev/null -w '%{http_code}' https://vagrant-story-api.criticalbit.gg/v1/blades?limit=1
200
$ curl -s https://vagrant-story-api.criticalbit.gg/.well-known/security.txt
Contact: mailto:security@criticalbit.gg
Expires: 2027-04-15T00:00:00.000Z
Preferred-Languages: en
\`\`\`

The unversioned mount (\`/blades\`, etc.) is retained by the API during the transition, so there is no window where this PR can break the live site regardless of Netlify build order.

## Test plan

- [x] \`pnpm run lint\` → 0 errors, 42 pre-existing warnings unchanged
- [x] \`pnpm run test:run\` → 16/16 pass
- [x] \`pnpm run build\` → full chain green, sitemap regenerated from live \`/v1\` endpoints, 830 URLs
- [ ] Post-deploy: click through homepage → list page → detail page on production, confirm data loads (trivial — the network requests just have a \`/v1\` segment now)

## Follow-ups

After this merges and deploys cleanly, the unversioned mount in the API can be removed in a small cleanup PR. Left on the table for now so we can confirm the /v1 migration actually works in production before committing to the one-way door.