### PR TITLE
refactor: rename RootErrorComponent to ErrorBoundary

### DIFF
--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { logger } from "@/lib/logger"
 import { captureException } from "@/lib/sentry"
 
-export function RootErrorComponent({ error, reset }: ErrorComponentProps) {
+export function ErrorBoundary({ error, reset }: ErrorComponentProps) {
   logger.error("Uncaught error in route component", {
     message: error.message,
     stack: error.stack,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import "@fontsource-variable/geist"
 import { ThemeProvider } from "./components/theme-provider"
 import "./index.css"
 import { getErrorMessage } from "./lib/api-errors"
-import { RootErrorComponent } from "./components/error-boundary"
+import { ErrorBoundary } from "./components/error-boundary"
 import { NotFound } from "./components/not-found"
 import { AuthProvider, useAuth } from "./lib/auth"
 import { AnalyticsProvider, createAnalyticsBackend } from "./lib/analytics"
@@ -47,7 +47,7 @@ const router = createRouter({
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
   scrollRestoration: true,
-  defaultErrorComponent: RootErrorComponent,
+  defaultErrorComponent: ErrorBoundary,
   defaultNotFoundComponent: NotFound,
 })
 

--- a/src/routes/crafting/index.tsx
+++ b/src/routes/crafting/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { RootErrorComponent } from "@/components/error-boundary"
+import { ErrorBoundary } from "@/components/error-boundary"
 import { CraftingPage } from "@/pages/crafting/crafting-page"
 
 export type CraftingSearch = {
@@ -15,7 +15,7 @@ export type CraftingSearch = {
 
 export const Route = createFileRoute("/crafting/")({
   component: CraftingPage,
-  errorComponent: RootErrorComponent,
+  errorComponent: ErrorBoundary,
   validateSearch: (search: Record<string, unknown>): CraftingSearch => ({
     s1: typeof search.s1 === "string" ? search.s1 : undefined,
     s2: typeof search.s2 === "string" ? search.s2 : undefined,

--- a/src/routes/material-grid.tsx
+++ b/src/routes/material-grid.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { RootErrorComponent } from "@/components/error-boundary"
+import { ErrorBoundary } from "@/components/error-boundary"
 import { CraftingMaterialsPage } from "@/pages/crafting/materials-page"
 
 export type MaterialsSearch = {
@@ -10,7 +10,7 @@ export type MaterialsSearch = {
 
 export const Route = createFileRoute("/material-grid")({
   component: CraftingMaterialsPage,
-  errorComponent: RootErrorComponent,
+  errorComponent: ErrorBoundary,
   validateSearch: (search: Record<string, unknown>): MaterialsSearch => ({
     cat: typeof search.cat === "string" ? search.cat : undefined,
     t1: typeof search.t1 === "string" ? search.t1 : undefined,


### PR DESCRIPTION
## Summary
- Rename `RootErrorComponent` → `ErrorBoundary` so the export matches the `error-boundary.tsx` filename. Easier IDE jump-to-symbol and grep.
- Touches the component itself, `main.tsx`, and the two routes that explicitly opt in to the boundary (`material-grid.tsx`, `crafting/index.tsx`).

## Test plan
- [ ] `pnpm build` and `pnpm test:run` pass
- [ ] App still boots and `/material-grid`, `/crafting` routes still render their error UI when thrown into