### PR TITLE
chore(csp): move CSP to public/_headers as single source of truth

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.criticalbit.gg https://us.i.posthog.com https://us-assets.i.posthog.com https://*.ingest.us.sentry.io; img-src 'self' data: https:; object-src 'none'; frame-src 'none'; form-action 'self'; upgrade-insecure-requests; base-uri 'self'"
-    />
     <title>Vagrant Story — criticalbit.gg</title>
     <meta
       name="description"

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,6 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.criticalbit.gg https://us.i.posthog.com https://us-assets.i.posthog.com https://*.ingest.us.sentry.io; img-src 'self' data: https:; object-src 'none'; frame-src 'none'; form-action 'self'; upgrade-insecure-requests; base-uri 'self'
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()


### PR DESCRIPTION
Closes #157.

## Summary
- Move the CSP from a `<meta>` tag in `index.html` to a new `public/_headers` file so Netlify serves it as an HTTP header. CSP string is unchanged.
- Add the standard security headers (`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`) in the same `_headers` file.

## Why
HTTP-header CSP is enforced before any HTML byte is parsed, and — more importantly — having two CSP sources (`_headers` + `<meta>`) is a silent footgun: browsers enforce the **intersection** of every CSP on a document. Sister project `hera-streamer-invitational-2026-web` ate exactly that footgun (see ag-tech-group/hera-streamer-invitational-2026-web#99) when a later `_headers` CSP intersected with an older narrower `<meta>` CSP and broke the auth API on prod. Removing the meta tag here, before that pattern emerges, kills the footgun preemptively.

## Test plan
- [ ] Deploy preview reachable.
- [ ] `curl -I` on the deploy preview shows `content-security-policy`, `x-frame-options`, `x-content-type-options`, `referrer-policy`, and `permissions-policy` headers.
- [ ] `view-source:` on the deploy preview shows **no** `<meta http-equiv="Content-Security-Policy">` element.
- [ ] Devtools console on the deploy preview is free of `Refused to connect`/`violates the following Content Security Policy directive` errors.
- [ ] Sign-in / sign-out flow still works.
- [ ] PostHog `array/<key>/config.js` and `static/surveys.js` still load.

No CSP content changed, so anything that worked under the meta-tag CSP should keep working under the header CSP.