### PR TITLE
fix: satisfy react-hooks/set-state-in-effect in auth.tsx

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -101,6 +101,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [clearState])
 
   useEffect(() => {
+    // checkAuth is async: its setState calls run after an await, not
+    // synchronously within the effect body, so cascading renders don't apply.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     checkAuth()
   }, [checkAuth])
 


### PR DESCRIPTION
## Why

eslint-plugin-react-hooks 7.1.x — arriving via the npm-minor-patch group PR — adds `set-state-in-effect`, which errors on the mount-time auth check in `src/lib/auth.tsx`.

## The fix

`checkAuth()` is async, so its setState calls run after an `await` rather than synchronously within the effect body; cascading renders don't apply. Disabled with that rationale rather than restructuring.

This is the same disable and comment that `ag-tech-group/web-template` already carries at the byte-identical call site, so it brings this repo back in line with the template.

## Sequencing

Landing separately from the group bump so a 30+ package dependency update isn't blocked on a pre-existing code pattern. Until the bump lands, the directive is unused — which eslint reports as a **warning**, not an error — so CI stays green either way.

## Verification

lint, format, typecheck, test and build all pass. Verified against eslint-plugin-react-hooks 7.1.1 that this brings error-severity findings to zero.
